### PR TITLE
Additional tests and changes to trouble random

### DIFF
--- a/spring-boot-chaos-monkey/pom.xml
+++ b/spring-boot-chaos-monkey/pom.xml
@@ -55,6 +55,11 @@
             <version>3.4</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${jcl-over-slf4j.version}</version>
@@ -74,12 +79,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
-            <version>${spring-boot.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>

--- a/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkey.java
+++ b/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkey.java
@@ -31,11 +31,8 @@ public class ChaosMonkey {
 
 
     public void callChaosMonkey() {
-        // Trouble?
-        int troubleRand = assaultProperties.getTroubleRandom();
-        int exceptionRand = assaultProperties.getExceptionRandom();
-
-        if (troubleRand > assaultProperties.getLevel()) {
+        if (isTrouble()) {
+            int exceptionRand = assaultProperties.getExceptionRandom();
 
             if (assaultProperties.isLatencyActive() && assaultProperties.isExceptionsActive()) {
                 // Timeout or Exception?
@@ -53,6 +50,10 @@ public class ChaosMonkey {
             }
 
         }
+    }
+
+    private boolean isTrouble() {
+        return assaultProperties.getTroubleRandom() >= assaultProperties.getLevel();
     }
 
     private void killTheBossApp() {

--- a/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -38,7 +38,7 @@ public class AssaultProperties {
 
     @JsonIgnore
     public int getTroubleRandom() {
-        return RandomUtils.nextInt(0, 10);
+        return RandomUtils.nextInt(1, 11);
     }
 
     @JsonIgnore

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationChaosMonkeyProfileTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationChaosMonkeyProfileTest.java
@@ -41,7 +41,6 @@ public class ChaosDemoApplicationChaosMonkeyProfileTest {
 
     @Test
     public void contextLoads() {
-
         assertNotNull(chaosMonkey);
     }
 

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationDefaultProfileTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationDefaultProfileTest.java
@@ -35,7 +35,7 @@ public class ChaosDemoApplicationDefaultProfileTest {
     }
 
     @Test
-    public void checkEnvironment() throws Exception {
+    public void checkEnvironment() {
         assertThat(env.getProperty("chaos.monkey.attack.controller"),is("true"));
     }
 }

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
@@ -54,7 +54,7 @@ public class ChaosMonkeyTest {
 
     @Before
     public void setUp() {
-        given(this.assaultProperties.getLevel()).willReturn(0);
+        given(this.assaultProperties.getLevel()).willReturn(1);
         given(this.assaultProperties.getTroubleRandom()).willReturn(10);
         chaosMonkey = new ChaosMonkey(assaultProperties);
 

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackControllerConditionTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackControllerConditionTest.java
@@ -1,0 +1,62 @@
+package de.codecentric.spring.boot.chaos.monkey.conditions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttackControllerConditionTest {
+
+    private AttackControllerCondition attackControllerCondition;
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.controller";
+    private final String FALSE_DEFAULT = "false";
+
+    @Mock
+    private ConditionContext conditionContext;
+    @Mock
+    private AnnotatedTypeMetadata annotatedTypeMetadata;
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void setup() {
+        given(conditionContext.getEnvironment()).willReturn(environment);
+
+        attackControllerCondition = new AttackControllerCondition();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsFalse() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("false");
+
+        boolean matches = attackControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsNotABoolean() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("notBoolean");
+
+        boolean matches = attackControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void matchesWhenConditionIsTrue() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("true");
+
+        boolean matches = attackControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isTrue();
+    }
+}

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRepositoryConditionTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRepositoryConditionTest.java
@@ -1,0 +1,62 @@
+package de.codecentric.spring.boot.chaos.monkey.conditions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttackRepositoryConditionTest {
+
+    private AttackRepositoryCondition attackRestControllerCondition;
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.repository";
+    private final String FALSE_DEFAULT = "false";
+
+    @Mock
+    private ConditionContext conditionContext;
+    @Mock
+    private AnnotatedTypeMetadata annotatedTypeMetadata;
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void setup() {
+        given(conditionContext.getEnvironment()).willReturn(environment);
+
+        attackRestControllerCondition = new AttackRepositoryCondition();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsFalse() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("false");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsNotABoolean() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("notBoolean");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void matchesWhenConditionIsTrue() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("true");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isTrue();
+    }
+}

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerConditionTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerConditionTest.java
@@ -1,0 +1,62 @@
+package de.codecentric.spring.boot.chaos.monkey.conditions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttackRestControllerConditionTest {
+
+    private AttackRestControllerCondition attackRestControllerCondition;
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.restController";
+    private final String FALSE_DEFAULT = "false";
+
+    @Mock
+    private ConditionContext conditionContext;
+    @Mock
+    private AnnotatedTypeMetadata annotatedTypeMetadata;
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void setup() {
+        given(conditionContext.getEnvironment()).willReturn(environment);
+
+        attackRestControllerCondition = new AttackRestControllerCondition();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsFalse() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("false");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsNotABoolean() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("notBoolean");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void matchesWhenConditionIsTrue() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("true");
+
+        boolean matches = attackRestControllerCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isTrue();
+    }
+}

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceConditionTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceConditionTest.java
@@ -1,0 +1,62 @@
+package de.codecentric.spring.boot.chaos.monkey.conditions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttackServiceConditionTest {
+
+    private AttackServiceCondition attackServiceCondition;
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.services";
+    private final String FALSE_DEFAULT = "false";
+
+    @Mock
+    private ConditionContext conditionContext;
+    @Mock
+    private AnnotatedTypeMetadata annotatedTypeMetadata;
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void setup() {
+        given(conditionContext.getEnvironment()).willReturn(environment);
+
+        attackServiceCondition = new AttackServiceCondition();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsFalse() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("false");
+
+        boolean matches = attackServiceCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void doesNotMatchWhenConditionIsNotABoolean() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("notBoolean");
+
+        boolean matches = attackServiceCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void matchesWhenConditionIsTrue() {
+        given(environment.getProperty(CHAOS_MONKEY_CONTROL_CONDITION, FALSE_DEFAULT)).willReturn("true");
+
+        boolean matches = attackServiceCondition.matches(conditionContext, annotatedTypeMetadata);
+
+        assertThat(matches).isTrue();
+    }
+}


### PR DESCRIPTION
Hi,

I like the idea of creating a library for introducing chaos monkey in Spring Boot (might be able to use this at work), so decided to contribute a little bit. 

Summarized, the pull request does the following:

- tries to improve test coverage by adding some unit tests
- does some cleanup (like removing exceptions that aren't thrown)
- reworks the troubleRandom

Last part probably requires some explanation. The issue I have with getTroubleRandom() is that it does not match the documentation, which says:

> "chaos.monkey.assaults.level: How many requests are to be attacked. 1 each request, 5 each 5th request is attacked"

Which I think means when the level is 1, **every** request is attacked.

But this:

`return RandomUtils.nextInt(0, 10);`

Will return numbers **including** 0, meaning at level 1, the condition will sometimes be false and chaos monkey will ignore some 10% of requests. And if you fill in 10, chaos monkey will not attack every 10th request. Instead, it will never do anything (RandomUtils is endExclusive).

You could change the documentation, but I think it is more intuitive when level 1 means every request is attacked. So I changed the code.

In case you think otherwise (or if the above thought process here is wrong), I separated that change from the others, putting it in a different commit, so you can ignore it more easily. :)

Thanks