### PR TITLE
chaos.monkey.watcher.services -> chaos.monkey.watcher.service

### DIFF
--- a/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceCondition.java
+++ b/spring-boot-chaos-monkey/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceCondition.java
@@ -13,7 +13,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 public class AttackServiceCondition implements Condition {
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         return context.getEnvironment()
-                .getProperty("chaos.monkey.watcher.services","false")
+                .getProperty("chaos.monkey.watcher.service","false")
                 .matches("(?i:.*true*)");
     }
 }

--- a/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceConditionTest.java
+++ b/spring-boot-chaos-monkey/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackServiceConditionTest.java
@@ -16,7 +16,7 @@ import static org.mockito.BDDMockito.given;
 public class AttackServiceConditionTest {
 
     private AttackServiceCondition attackServiceCondition;
-    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.services";
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.service";
     private final String FALSE_DEFAULT = "false";
 
     @Mock


### PR DESCRIPTION
is not this a bug?

WatcherProperties.class
```java
    @Value("${service:true}")
    private boolean service;
```
AttackServiceCondition.class

```java
.getProperty("chaos.monkey.watcher.services","false")
```
