### PR TITLE
Make it possible to configure specific services to be watched

### DIFF
--- a/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/controller/HelloController.java
+++ b/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/controller/HelloController.java
@@ -31,6 +31,11 @@ public class HelloController {
         return ResponseEntity.ok(sayHelloPlease());
     }
 
+    @GetMapping("/goodbye")
+    public ResponseEntity<String> sayGoodbye() {
+        return ResponseEntity.ok("Goodbye!");
+    }
+
     private String sayHelloPlease() {
         return "Hello!";
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -17,6 +17,7 @@
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -59,6 +60,8 @@ public class AssaultProperties {
 
     @Value("${killApplicationActive : false}")
     private boolean killApplicationActive;
+
+    private List<String> watchedServices;
 
     @JsonIgnore
     public int getTroubleRandom() {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -61,7 +61,7 @@ public class AssaultProperties {
     @Value("${killApplicationActive : false}")
     private boolean killApplicationActive;
 
-    private List<String> watchedServices;
+    private List<String> watchedCustomServices;
 
     @JsonIgnore
     public int getTroubleRandom() {
@@ -71,6 +71,13 @@ public class AssaultProperties {
     @JsonIgnore
     public int chooseAssault(int amount) {
         return RandomUtils.nextInt(0, amount);
+    }
+
+    @JsonIgnore
+    public boolean isWatchedCustomServicesActive() {
+        if(watchedCustomServices == null || watchedCustomServices.isEmpty())
+            return false;
+        return true;
     }
 
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -43,7 +43,7 @@ import java.util.List;
  */
 @Configuration
 @Profile("chaos-monkey")
-@EnableConfigurationProperties({ChaosMonkeyProperties.class,AssaultProperties.class, WatcherProperties.class})
+@EnableConfigurationProperties({ChaosMonkeyProperties.class, AssaultProperties.class, WatcherProperties.class})
 public class ChaosMonkeyConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChaosMonkey.class);
     private final ChaosMonkeyProperties chaosMonkeyProperties;
@@ -108,7 +108,7 @@ public class ChaosMonkeyConfiguration {
     @Bean
     @Conditional(AttackServiceCondition.class)
     public SpringServiceAspect serviceAspect(ChaosMonkey chaosMonkey) {
-        return new SpringServiceAspect(chaosMonkey, chaosMonkeySettings);
+        return new SpringServiceAspect(chaosMonkey);
     }
 
     @Bean

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -49,6 +49,7 @@ public class ChaosMonkeyConfiguration {
     private final ChaosMonkeyProperties chaosMonkeyProperties;
     private final WatcherProperties watcherProperties;
     private final AssaultProperties assaultProperties;
+    private ChaosMonkeySettings chaosMonkeySettings;
 
 
     public ChaosMonkeyConfiguration(ChaosMonkeyProperties chaosMonkeyProperties, WatcherProperties watcherProperties,
@@ -68,7 +69,8 @@ public class ChaosMonkeyConfiguration {
 
     @Bean
     public ChaosMonkeySettings settings() {
-        return new ChaosMonkeySettings(chaosMonkeyProperties, assaultProperties, watcherProperties);
+        chaosMonkeySettings = new ChaosMonkeySettings(chaosMonkeyProperties, assaultProperties, watcherProperties);
+        return chaosMonkeySettings;
     }
 
     @Bean
@@ -106,7 +108,7 @@ public class ChaosMonkeyConfiguration {
     @Bean
     @Conditional(AttackServiceCondition.class)
     public SpringServiceAspect serviceAspect(ChaosMonkey chaosMonkey) {
-        return new SpringServiceAspect(chaosMonkey);
+        return new SpringServiceAspect(chaosMonkey, chaosMonkeySettings);
     }
 
     @Bean

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
@@ -16,16 +16,24 @@
 
 package de.codecentric.spring.boot.chaos.monkey.watcher;
 
+import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint;
 
 /**
  * @author Benjamin Wilms
  */
 abstract class ChaosMonkeyBaseAspect {
     @Pointcut("within(de.codecentric.spring.boot.chaos.monkey..*)")
-    public void classInChaosMonkeyPackage() { }
+    public void classInChaosMonkeyPackage() {
+    }
 
     @Pointcut("execution(* *.*(..))")
     public void allPublicMethodPointcut() {
+    }
+
+    protected String createSignature(MethodSignature signature) {
+        return signature.getDeclaringTypeName() + "." + signature.getMethod().getName();
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
@@ -18,9 +18,11 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +46,9 @@ public class SpringComponentAspect extends ChaosMonkeyBaseAspect{
 
     @Around("classAnnotatedWithComponentPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
     public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
-        LOGGER.debug(LOGGER.isDebugEnabled() ? "Component class and public method detected: " + pjp.getSignature() : null);
+        MethodSignature signature = (MethodSignature) pjp.getSignature();
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(createSignature(signature));
 
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspect.java
@@ -18,9 +18,11 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +46,10 @@ public class SpringControllerAspect extends ChaosMonkeyBaseAspect{
 
     @Around("classAnnotatedWithControllerPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
     public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
-        LOGGER.debug(LOGGER.isDebugEnabled() ? "Controller class and public method detected: " + pjp.getSignature() : null);
 
-        chaosMonkey.callChaosMonkey();
+        MethodSignature signature = (MethodSignature) pjp.getSignature();
+
+        chaosMonkey.callChaosMonkey(createSignature(signature));
 
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspect.java
@@ -18,9 +18,11 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +46,9 @@ public class SpringRepositoryAspect extends ChaosMonkeyBaseAspect{
 
     @Around("classAnnotatedWithControllerPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
     public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
-        LOGGER.debug(LOGGER.isDebugEnabled() ? "Controller class and public method detected: " + pjp.getSignature() : null);
+        MethodSignature signature = (MethodSignature) pjp.getSignature();
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(createSignature(signature));
 
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspect.java
@@ -18,9 +18,11 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +46,10 @@ public class SpringRestControllerAspect extends ChaosMonkeyBaseAspect {
 
     @Around("classAnnotatedWithControllerPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
     public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
-        LOGGER.debug(LOGGER.isDebugEnabled() ? "RestController class and public method detected: " + pjp.getSignature() : null);
 
-        chaosMonkey.callChaosMonkey();
+        MethodSignature signature = (MethodSignature) pjp.getSignature();
+
+        chaosMonkey.callChaosMonkey(createSignature(signature));
 
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspect.java
@@ -19,8 +19,10 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
+
 import java.util.Collections;
 import java.util.List;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
@@ -39,11 +41,9 @@ public class SpringServiceAspect extends ChaosMonkeyBaseAspect {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringServiceAspect.class);
 
     private final ChaosMonkey chaosMonkey;
-    private final ChaosMonkeySettings chaosMonkeySettings;
 
-    public SpringServiceAspect(ChaosMonkey chaosMonkey, ChaosMonkeySettings chaosMonkeySettings) {
+    public SpringServiceAspect(ChaosMonkey chaosMonkey) {
         this.chaosMonkey = chaosMonkey;
-        this.chaosMonkeySettings = chaosMonkeySettings;
     }
 
     @Pointcut("within(@org.springframework.stereotype.Service *)")
@@ -55,19 +55,7 @@ public class SpringServiceAspect extends ChaosMonkeyBaseAspect {
         final Signature signature = pjp.getSignature();
         LOGGER.debug(LOGGER.isDebugEnabled() ? "Controller class and public method detected: " + signature : null);
 
-        final AssaultProperties assaultProperties = chaosMonkeySettings.getAssaultProperties();
-
-        if (assaultProperties != null) {
-            final List<String> watchedServices = assaultProperties.getWatchedServices() != null
-                ? assaultProperties.getWatchedServices()
-                : Collections.emptyList();
-
-            if (watchedServices.isEmpty() || watchedServices.contains(signature.getDeclaringType().getSimpleName())) {
-                chaosMonkey.callChaosMonkey();
-            }
-        } else {
-            chaosMonkey.callChaosMonkey();
-        }
+        chaosMonkey.callChaosMonkey(signature.getDeclaringType().getCanonicalName());
 
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
@@ -77,7 +77,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(3)).willReturn(0);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, times(1)).attack();
     }
@@ -89,7 +89,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(3)).willReturn(1);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(exceptionAssault, times(1)).attack();
     }
@@ -101,7 +101,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(3)).willReturn(2);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(killAppAssault, times(1)).attack();
     }
@@ -113,7 +113,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.chaosMonkeyProperties.isEnabled()).willReturn(true);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(killAppAssault, times(1)).attack();
     }
@@ -124,7 +124,7 @@ public class ChaosMonkeyTest {
         given(this.exceptionAssault.isActive()).willReturn(false);
         given(this.killAppAssault.isActive()).willReturn(false);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, times(1)).attack();
     }
@@ -135,7 +135,7 @@ public class ChaosMonkeyTest {
         given(this.latencyAssault.isActive()).willReturn(false);
         given(this.killAppAssault.isActive()).willReturn(false);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(exceptionAssault, times(1)).attack();
     }
@@ -147,7 +147,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(false);
         given(this.assaultProperties.chooseAssault(2)).willReturn(1);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(exceptionAssault, times(1)).attack();
     }
@@ -160,7 +160,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(false);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, times(1)).attack();
     }
@@ -172,7 +172,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(exceptionAssault, times(1)).attack();
     }
@@ -184,7 +184,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(1);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(killAppAssault, times(1)).attack();
     }
@@ -196,7 +196,7 @@ public class ChaosMonkeyTest {
         given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, times(1)).attack();
     }
@@ -208,7 +208,7 @@ public class ChaosMonkeyTest {
         given(killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(1);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(killAppAssault, times(1)).attack();
     }
@@ -219,7 +219,7 @@ public class ChaosMonkeyTest {
         given(latencyAssault.isActive()).willReturn(false);
         given(killAppAssault.isActive()).willReturn(false);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
@@ -232,7 +232,7 @@ public class ChaosMonkeyTest {
         given(this.assaultProperties.getTroubleRandom()).willReturn(9);
         given(this.latencyAssault.isActive()).willReturn(true);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
@@ -243,10 +243,44 @@ public class ChaosMonkeyTest {
     public void isChaosMonkeyExecutionDisabled() {
         given(this.chaosMonkeyProperties.isEnabled()).willReturn(false);
 
-        chaosMonkey.callChaosMonkey();
+        chaosMonkey.callChaosMonkey(null);
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
         verify(killAppAssault, never()).attack();
+    }
+
+    @Test
+    public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
+        String customService = "CustomService";
+
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Arrays.asList(customService));
+        given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
+
+        chaosMonkey.callChaosMonkey("notInListService");
+
+        verify(latencyAssault, never()).attack();
+        verify(exceptionAssault, never()).attack();
+        verify(killAppAssault, never()).attack();
+
+    }
+
+    @Test
+    public void chaosMonkeyIsCalledWhenServiceNotWatched() {
+        String customService = "CustomService";
+
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Arrays.asList(customService));
+        given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
+        given(killAppAssault.isActive()).willReturn(true);
+        given(this.assaultProperties.chooseAssault(2)).willReturn(1);
+
+        chaosMonkey.callChaosMonkey(customService);
+
+        verify(latencyAssault, never()).attack();
+        verify(exceptionAssault, never()).attack();
+        verify(killAppAssault, times(1)).attack();
+
     }
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpointIntTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpointIntTest.java
@@ -124,7 +124,7 @@ public class ChaosMonkeyRestEndpointIntTest {
     @Test
     public void postAssaultConfigurationGoodCase() {
         AssaultProperties assaultProperties = new AssaultProperties();
-        assaultProperties.setLevel(1000);
+        assaultProperties.setLevel(10);
         assaultProperties.setLatencyRangeEnd(100);
         assaultProperties.setLatencyRangeStart(200);
         assaultProperties.setLatencyActive(true);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
@@ -51,7 +51,7 @@ public class SpringComponentAspectTest {
         DemoComponent proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }
@@ -63,7 +63,7 @@ public class SpringComponentAspectTest {
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(repositoryAspect);
@@ -73,7 +73,7 @@ public class SpringComponentAspectTest {
         DemoComponent proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
@@ -18,6 +18,7 @@ package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,9 @@ public class SpringComponentAspectTest {
 
     @Mock
     private ChaosMonkey chaosMonkeyMock;
+
+    @Mock
+    private ChaosMonkeySettings chaosMonkeySettings;
 
     @Test
     public void chaosMonkeyIsCalled() {
@@ -59,7 +63,7 @@ public class SpringComponentAspectTest {
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(repositoryAspect);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
@@ -16,6 +16,7 @@
 
 package de.codecentric.spring.boot.chaos.monkey.watcher;
 
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.demo.chaos.monkey.controller.DemoController;
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.junit.Test;
@@ -36,6 +37,9 @@ public class SpringControllerAspectTest {
 
     @Mock
     private ChaosMonkey chaosMonkeyMock;
+
+    @Mock
+    private ChaosMonkeySettings chaosMonkeySettings;
 
     @Test
     public void chaosMonkeyIsCalled() {
@@ -59,7 +63,7 @@ public class SpringControllerAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(repositoryAspect);
         factory.addAspect(serviceAspect);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
@@ -52,7 +52,7 @@ public class SpringControllerAspectTest {
         DemoController proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.controller.DemoController.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }
@@ -63,7 +63,7 @@ public class SpringControllerAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(repositoryAspect);
         factory.addAspect(serviceAspect);
@@ -72,7 +72,7 @@ public class SpringControllerAspectTest {
         DemoController proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.controller.DemoController.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
@@ -50,7 +50,7 @@ public class SpringRepositoryAspectTest {
         DemoRepository proxy = factory.getProxy();
         proxy.dummyPublicSaveMethod();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepository.dummyPublicSaveMethod");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }
@@ -61,7 +61,7 @@ public class SpringRepositoryAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(serviceAspect);
@@ -70,7 +70,7 @@ public class SpringRepositoryAspectTest {
         DemoRepository proxy = factory.getProxy();
         proxy.dummyPublicSaveMethod();
 
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepository.dummyPublicSaveMethod");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
@@ -16,6 +16,7 @@
 
 package de.codecentric.spring.boot.chaos.monkey.watcher;
 
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepository;
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import org.junit.Test;
@@ -34,6 +35,9 @@ public class SpringRepositoryAspectTest {
 
     @Mock
     private ChaosMonkey chaosMonkeyMock;
+
+    @Mock
+    private ChaosMonkeySettings chaosMonkeySettings;
 
     @Test
     public void chaosMonkeyIsCalled() {
@@ -57,7 +61,7 @@ public class SpringRepositoryAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(serviceAspect);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
@@ -17,6 +17,7 @@
 package de.codecentric.spring.boot.chaos.monkey.watcher;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.demo.chaos.monkey.restcontroller.DemoRestController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,9 @@ public class SpringRestControllerAspectTest {
 
     @Mock
     private ChaosMonkey chaosMonkeyMock;
+
+    @Mock
+    private ChaosMonkeySettings chaosMonkeySettings;
 
     @Test
     public void chaosMonkeyIsCalled() {
@@ -57,7 +61,7 @@ public class SpringRestControllerAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(serviceAspect);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
@@ -50,7 +50,7 @@ public class SpringRestControllerAspectTest {
         DemoRestController proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.restcontroller.DemoRestController.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }
@@ -61,7 +61,7 @@ public class SpringRestControllerAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(serviceAspect);
@@ -71,7 +71,7 @@ public class SpringRestControllerAspectTest {
         DemoRestController proxy = factory.getProxy();
         proxy.sayHello();
 
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey("de.codecentric.spring.boot.demo.chaos.monkey.restcontroller.DemoRestController.sayHello");
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
@@ -25,8 +25,10 @@ import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.demo.chaos.monkey.service.DemoService;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -42,21 +44,20 @@ public class SpringServiceAspectTest {
     @Mock
     private ChaosMonkey chaosMonkeyMock;
 
-    @Mock
-    private ChaosMonkeySettings chaosMonkeySettings;
+    private String testSignature = "com.test.Class.method";
 
     @Test
     public void chaosMonkeyIsCalled() {
         DemoService serviceTarget = new DemoService();
 
         AspectJProxyFactory factory = new AspectJProxyFactory(serviceTarget);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         factory.addAspect(serviceAspect);
 
         DemoService proxy = factory.getProxy();
         proxy.sayHelloService();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey(DemoService.class.getCanonicalName());
         verifyNoMoreInteractions(chaosMonkeyMock);
 
     }
@@ -76,36 +77,9 @@ public class SpringServiceAspectTest {
         DemoService proxy = factory.getProxy();
         proxy.sayHelloService();
 
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey(DemoService.class.getCanonicalName());
         verifyNoMoreInteractions(chaosMonkeyMock);
 
-    }
-
-    @Test
-    public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
-        DemoService target = new DemoService();
-
-        AspectJProxyFactory factory = new AspectJProxyFactory(target);
-        SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
-        SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
-        factory.addAspect(controllerAspect);
-        factory.addAspect(restControllerAspect);
-        factory.addAspect(repositoryAspect);
-        factory.addAspect(serviceAspect);
-
-        final List<String> watchedServices = new ArrayList<>();
-        watchedServices.add("TestService");
-
-        when(chaosMonkeySettings.getAssaultProperties())
-            .thenReturn(assaultPropertyWithWatchedServices(watchedServices));
-
-        DemoService proxy = factory.getProxy();
-        proxy.sayHelloService();
-
-        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
-        verifyNoMoreInteractions(chaosMonkeyMock);
     }
 
     @Test
@@ -116,28 +90,18 @@ public class SpringServiceAspectTest {
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
         SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
         factory.addAspect(restControllerAspect);
         factory.addAspect(repositoryAspect);
         factory.addAspect(serviceAspect);
 
-        final List<String> watchedServices = new ArrayList<>();
-        watchedServices.add("DemoService");
-
-        when(chaosMonkeySettings.getAssaultProperties())
-            .thenReturn(assaultPropertyWithWatchedServices(watchedServices));
-
         DemoService proxy = factory.getProxy();
         proxy.sayHelloService();
 
-        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey(DemoService.class.getCanonicalName());
         verifyNoMoreInteractions(chaosMonkeyMock);
     }
 
-    private AssaultProperties assaultPropertyWithWatchedServices(List<String> watchedServices) {
-        AssaultProperties assaultProperties = new AssaultProperties();
-        assaultProperties.setWatchedServices(watchedServices);
-        return assaultProperties;
-    }
+
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
@@ -16,15 +16,22 @@
 
 package de.codecentric.spring.boot.chaos.monkey.watcher;
 
-import de.codecentric.spring.boot.demo.chaos.monkey.service.DemoService;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkey;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
+import de.codecentric.spring.boot.demo.chaos.monkey.service.DemoService;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
-
-import static org.mockito.Mockito.*;
 
 /**
  * @author Benjamin Wilms
@@ -35,12 +42,15 @@ public class SpringServiceAspectTest {
     @Mock
     private ChaosMonkey chaosMonkeyMock;
 
+    @Mock
+    private ChaosMonkeySettings chaosMonkeySettings;
+
     @Test
     public void chaosMonkeyIsCalled() {
         DemoService serviceTarget = new DemoService();
 
         AspectJProxyFactory factory = new AspectJProxyFactory(serviceTarget);
-        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
         factory.addAspect(serviceAspect);
 
         DemoService proxy = factory.getProxy();
@@ -57,12 +67,11 @@ public class SpringServiceAspectTest {
 
         AspectJProxyFactory factory = new AspectJProxyFactory(target);
         SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
-        SpringRestControllerAspect serviceAspect = new SpringRestControllerAspect(chaosMonkeyMock);
+        SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
         SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
         factory.addAspect(controllerAspect);
-        factory.addAspect(serviceAspect);
+        factory.addAspect(restControllerAspect);
         factory.addAspect(repositoryAspect);
-
 
         DemoService proxy = factory.getProxy();
         proxy.sayHelloService();
@@ -70,5 +79,65 @@ public class SpringServiceAspectTest {
         verify(chaosMonkeyMock, times(0)).callChaosMonkey();
         verifyNoMoreInteractions(chaosMonkeyMock);
 
+    }
+
+    @Test
+    public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
+        DemoService target = new DemoService();
+
+        AspectJProxyFactory factory = new AspectJProxyFactory(target);
+        SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
+        SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
+        SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        factory.addAspect(controllerAspect);
+        factory.addAspect(restControllerAspect);
+        factory.addAspect(repositoryAspect);
+        factory.addAspect(serviceAspect);
+
+        final List<String> watchedServices = new ArrayList<>();
+        watchedServices.add("TestService");
+
+        when(chaosMonkeySettings.getAssaultProperties())
+            .thenReturn(assaultPropertyWithWatchedServices(watchedServices));
+
+        DemoService proxy = factory.getProxy();
+        proxy.sayHelloService();
+
+        verify(chaosMonkeyMock, times(0)).callChaosMonkey();
+        verifyNoMoreInteractions(chaosMonkeyMock);
+    }
+
+    @Test
+    public void chaosMonkeyIsCalledWhenServiceWatched() {
+        DemoService target = new DemoService();
+
+        AspectJProxyFactory factory = new AspectJProxyFactory(target);
+        SpringControllerAspect controllerAspect = new SpringControllerAspect(chaosMonkeyMock);
+        SpringRestControllerAspect restControllerAspect = new SpringRestControllerAspect(chaosMonkeyMock);
+        SpringRepositoryAspect repositoryAspect = new SpringRepositoryAspect(chaosMonkeyMock);
+        SpringServiceAspect serviceAspect = new SpringServiceAspect(chaosMonkeyMock, chaosMonkeySettings);
+        factory.addAspect(controllerAspect);
+        factory.addAspect(restControllerAspect);
+        factory.addAspect(repositoryAspect);
+        factory.addAspect(serviceAspect);
+
+        final List<String> watchedServices = new ArrayList<>();
+        watchedServices.add("DemoService");
+
+        when(chaosMonkeySettings.getAssaultProperties())
+            .thenReturn(assaultPropertyWithWatchedServices(watchedServices));
+
+        DemoService proxy = factory.getProxy();
+        proxy.sayHelloService();
+
+        verify(chaosMonkeyMock, times(1)).callChaosMonkey();
+        verifyNoMoreInteractions(chaosMonkeyMock);
+    }
+
+    private AssaultProperties assaultPropertyWithWatchedServices(List<String> watchedServices) {
+        AssaultProperties assaultProperties = new AssaultProperties();
+        assaultProperties.setWatchedServices(watchedServices);
+        return assaultProperties;
     }
 }


### PR DESCRIPTION
We have the need to configure specific services. Therefore, I forked the project and created this Pull Request to see if it would be possible to get these changes into master.

I also fixed a broken test while I was at it in ChaosMonkeyRestEndpointIntTest.

JUnit tests also added for the new feature. 

This could also be added for the other watches in the future if this would get approved.

I'm open to feedback if you prefer something done in some other way.

Thanks!