### PR TITLE
Fix trouble calculation

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkey.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkey.java
@@ -45,7 +45,7 @@ public class ChaosMonkey {
     }
 
     public void callChaosMonkey(String simpleName) {
-        if (isTrouble() && isEnabled()) {
+        if (isEnabled() && isTrouble()) {
             // Custom watched services can be defined at runtime, if there are any, only these will be attacked!
             if (chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()) {
                 if (chaosMonkeySettings.getAssaultProperties().getWatchedCustomServices().contains(simpleName)) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -39,7 +39,7 @@ public class AssaultProperties {
 
     @Value("${level : 5}")
     @Min(value = 1)
-    @Max(value = 100)
+    @Max(value = 10000)
     private int level;
 
     @Value("${latencyRangeStart : 1000}")
@@ -66,7 +66,7 @@ public class AssaultProperties {
 
     @JsonIgnore
     public int getTroubleRandom() {
-        return RandomUtils.nextInt(1, 1001);
+        return RandomUtils.nextInt(1, getLevel()+1);
     }
 
     @JsonIgnore

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyTest.java
@@ -62,7 +62,7 @@ public class ChaosMonkeyTest {
     @Before
     public void setUp() {
         given(this.assaultProperties.getLevel()).willReturn(1);
-        given(this.assaultProperties.getTroubleRandom()).willReturn(5);
+        given(this.assaultProperties.getTroubleRandom()).willReturn(1);
         given(this.chaosMonkeyProperties.isEnabled()).willReturn(true);
         given(this.chaosMonkeySettings.getAssaultProperties()).willReturn(this.assaultProperties);
         given(this.chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(this.chaosMonkeyProperties);


### PR DESCRIPTION
I noticed that the trouble calculation was inaccurate while running.

If you for example configured a level of 10, the isTrouble would return a value in the range of 1-1000 which does not mean every 10th request.

Instead I rewrote it to use the configured level(+1) as the upper bound of the range. And after this, the isTrouble calculation is working a lot better.

This new way of calculating trouble will also allow for a more flexible level configuration. I increased the max level to 10000 now, but this could potentially even be increased to max int, if that would be wanted.

I also moved isEnabled() before isTrouble(), so that we do not need to retrieve randoms all the time when chaos monkey is disabled.

---

Also, not a biggie, but during my last contribution I wasn't added as a contributor on the project. I am not sure how that works, and if there are any other requirements to become a contributor other than having a commit merged in.