### PR TITLE
Add support for raising configurable exception.

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssault.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssault.java
@@ -18,6 +18,8 @@ package de.codecentric.spring.boot.chaos.monkey.assaults;
 
 import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
 import de.codecentric.spring.boot.chaos.monkey.component.MetricType;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,10 +47,13 @@ public class ExceptionAssault implements ChaosMonkeyAssault {
     public void attack() {
         LOGGER.info("Chaos Monkey - exception");
 
+        AssaultProperties assaultProperties = this.settings.getAssaultProperties();
+        AssaultException assaultException = assaultProperties.getException();
+
         // metrics
         if (metricEventPublisher != null)
             metricEventPublisher.publishMetricEvent(MetricType.EXCEPTION_ASSAULT);
 
-        throw new RuntimeException("Chaos Monkey - RuntimeException");
+        throw assaultException.getExceptionInstance();
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
@@ -39,6 +39,7 @@ public class AssaultException {
         @NotNull
         private String value;
 
+        @JsonIgnore
         public Class<?> getClassType() {
             try {
                 return Class.forName(className);

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
@@ -1,0 +1,86 @@
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@ConfigurationProperties(prefix = "chaos.monkey.assaults.exception")
+public class AssaultException {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssaultException.class);
+
+    @Value("${type : java.lang.RuntimeException}")
+    private String type;
+
+    @Value("${arguments : #{null}}")
+    private List<ExceptionArgument> arguments;
+
+    public List<ExceptionArgument> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(List<ExceptionArgument> arguments) {
+        this.arguments = arguments;
+    }
+
+    @Data
+    public static class ExceptionArgument {
+        @NotNull
+        private String className;
+
+        @NotNull
+        private String value;
+
+        public Class<?> getClassType() {
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Class not found for class name: " + className);
+            }
+        }
+    }
+
+    @JsonIgnore
+    public RuntimeException getExceptionInstance() {
+        try {
+            Class<? extends RuntimeException> exceptionClass = getExceptionClass();
+            if (arguments == null) {
+                Constructor<?> constructor = exceptionClass.getConstructor();
+                return (RuntimeException) constructor.newInstance();
+            } else {
+                Constructor<?> constructor = exceptionClass.getConstructor(this.getExceptionArgumentTypes().toArray(new Class[0]));
+                return (RuntimeException) constructor.newInstance(this.getExceptionArgumentValues().toArray(new Object[0]));
+            }
+        } catch (ReflectiveOperationException e) {
+            LOGGER.warn("Cannot instantiate the class for provided type: {}. Fallback: Throw RuntimeException", type);
+            return new RuntimeException("Chaos Monkey - RuntimeException");
+        }
+    }
+
+    @JsonIgnore
+    public Class<? extends RuntimeException> getExceptionClass() throws ClassNotFoundException {
+        if (type == null) {
+            type = "java.lang.RuntimeException";
+        }
+        return (Class<? extends RuntimeException>) Class.forName(type);
+    }
+
+    @JsonIgnore
+    public List<Class> getExceptionArgumentTypes() {
+        return arguments.stream().map(ExceptionArgument::getClassType).collect(Collectors.toList());
+    }
+
+    @JsonIgnore
+    private List<Object> getExceptionArgumentValues() {
+        return arguments.stream().map(ExceptionArgument::getValue).collect(Collectors.toList());
+    }
+}
+

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionConstraint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionConstraint.java
@@ -1,0 +1,20 @@
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = AssaultExceptionValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AssaultExceptionConstraint {
+    String message() default "Invalid Exception type and arguments";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionValidator.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionValidator.java
@@ -1,0 +1,31 @@
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class AssaultExceptionValidator implements ConstraintValidator<AssaultExceptionConstraint, AssaultException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssaultExceptionValidator.class);
+
+    @Override
+    public boolean isValid(AssaultException exception, ConstraintValidatorContext constraintValidatorContext) {
+        if (exception == null) {
+            return true;
+        }
+
+        try {
+            Class<? extends RuntimeException> exceptionClass = exception.getExceptionClass();
+            if (exception.getArguments() == null) {
+                exceptionClass.getConstructor();
+            } else {
+                exceptionClass.getConstructor(exception.getExceptionArgumentTypes().toArray(new Class[0]));
+            }
+            return true;
+        } catch (ReflectiveOperationException e) {
+            LOGGER.warn("Invalid combination of type ({}) and arguments provided", exception.getType());
+        }
+        return false;
+    }
+}

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -18,7 +18,6 @@ package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -35,10 +34,8 @@ import java.util.concurrent.ThreadLocalRandom;
 @Data
 @NoArgsConstructor
 @ConfigurationProperties(prefix = "chaos.monkey.assaults")
-@EqualsAndHashCode
 @Validated
 public class AssaultProperties {
-
     @Value("${level : 5}")
     @Min(value = 1)
     @Max(value = 10000)
@@ -60,11 +57,22 @@ public class AssaultProperties {
     @Value("${exceptionsActive : false}")
     private boolean exceptionsActive;
 
+    @AssaultExceptionConstraint
+    private AssaultException exception;
+
     @Value("${killApplicationActive : false}")
     private boolean killApplicationActive;
 
     @Value("${watchedCustomServices:#{null}}")
     private List<String> watchedCustomServices;
+
+    public AssaultException getException() {
+        return exception;
+    }
+
+    public void setException(AssaultException exception) {
+        this.exception = exception;
+    }
 
     @JsonIgnore
     public int getTroubleRandom() {
@@ -78,10 +86,7 @@ public class AssaultProperties {
 
     @JsonIgnore
     public boolean isWatchedCustomServicesActive() {
-        if (watchedCustomServices == null || watchedCustomServices.isEmpty())
-            return false;
-        return true;
+        return watchedCustomServices != null && !watchedCustomServices.isEmpty();
     }
-
 
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -39,7 +39,6 @@ public class ChaosMonkeyRestEndpoint {
 
     @PostMapping("/assaults")
     public ResponseEntity<String> updateAssaultProperties(@RequestBody @Validated AssaultProperties assaultProperties) {
-
         this.chaosMonkeySettings.setAssaultProperties(assaultProperties);
         return ResponseEntity.ok().body("Assault config has changed");
     }
@@ -76,7 +75,7 @@ public class ChaosMonkeyRestEndpoint {
 
     /***
      * Watcher can only be viewed, not changed at runtime. They are initialized at Application start.
-     * @return
+     * @return watch settings
      */
     @GetMapping("/watcher")
     public WatcherProperties getWatcherSettings() {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
@@ -17,11 +17,18 @@
 package de.codecentric.spring.boot.chaos.monkey.assaults;
 
 import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
-import de.codecentric.spring.boot.chaos.monkey.component.Metrics;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+
+import java.util.Collections;
+
+import static org.hamcrest.core.Is.isA;
+
 
 /**
  * @author Thorsten Deelmann
@@ -35,11 +42,98 @@ public class ExceptionAssaultTest {
     private MetricEventPublisher metricsMock;
 
     @Test
-    public void throwsRuntimeException() {
+    public void throwsRuntimeExceptionWithDefaultAssaultSettings() {
         exception.expect(RuntimeException.class);
-        exception.expectMessage("Chaos Monkey - RuntimeException");
 
-        ExceptionAssault exceptionAssault = new ExceptionAssault(null, metricsMock);
+        ExceptionAssault exceptionAssault = new ExceptionAssault(getChaosMonkeySettings(), metricsMock);
         exceptionAssault.attack();
+    }
+
+    @Test
+    public void throwsRuntimeExceptionWithNullTypeAndNullArgument() {
+        exception.expect(RuntimeException.class);
+
+        ChaosMonkeySettings settings = getChaosMonkeySettings();
+        settings.getAssaultProperties().setException(null);
+        ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+        exceptionAssault.attack();
+    }
+
+    @Test
+    public void throwsRuntimeExceptionWithNullTypeAndNonNullArgument() {
+        String exceptionArgumentClassName = "java.lang.String";
+        String exceptionArgumentValue = "Exception message";
+        exception.expect(RuntimeException.class);
+        exception.expectMessage(exceptionArgumentValue);
+
+        ChaosMonkeySettings settings = getChaosMonkeySettings();
+        settings.getAssaultProperties().setException(getAssaultException(null, exceptionArgumentClassName, exceptionArgumentValue));
+
+        ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+        exceptionAssault.attack();
+    }
+
+    @Test
+    public void throwsRuntimeExceptionWithNonNullTypeAndNullArgument() {
+        exception.expect(isA(ArithmeticException.class));
+
+        ChaosMonkeySettings settings = getChaosMonkeySettings();
+        settings.getAssaultProperties().setException(getAssaultException("java.lang.ArithmeticException", null, null));
+
+        ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+        exceptionAssault.attack();
+    }
+
+    @Test
+    public void throwsRuntimeExceptionWithNonnullTypeAndNonNullArgument() {
+        String exceptionArgumentClassName = "java.lang.String";
+        String exceptionArgumentValue = "ArithmeticException Test";
+
+        exception.expect(isA(ArithmeticException.class));
+        exception.expectMessage(exceptionArgumentValue);
+
+        ChaosMonkeySettings settings = getChaosMonkeySettings();
+        settings.getAssaultProperties().setException(
+                getAssaultException("java.lang.ArithmeticException", exceptionArgumentClassName, exceptionArgumentValue));
+
+        ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+        exceptionAssault.attack();
+    }
+
+    private ChaosMonkeySettings getChaosMonkeySettings() {
+        ChaosMonkeySettings settings = new ChaosMonkeySettings();
+        settings.setAssaultProperties(getDefaultAssaultProperties());
+        return settings;
+    }
+
+    private AssaultProperties getDefaultAssaultProperties() {
+        AssaultProperties assaultProperties = new AssaultProperties();
+        assaultProperties.setLevel(5);
+        assaultProperties.setLatencyRangeStart(1000);
+        assaultProperties.setLatencyRangeEnd(3000);
+        assaultProperties.setLatencyActive(true);
+        assaultProperties.setExceptionsActive(false);
+        assaultProperties.setException(getAssaultException(null, null, null));
+        assaultProperties.setKillApplicationActive(false);
+        assaultProperties.setWatchedCustomServices(null);
+
+        return assaultProperties;
+    }
+
+    private AssaultException getAssaultException(String exceptionClassName, String argumentClass, String argumentValue) {
+        AssaultException assaultException = new AssaultException();
+
+        if (exceptionClassName != null) {
+            assaultException.setType(exceptionClassName);
+        }
+
+        if (argumentClass != null) {
+            AssaultException.ExceptionArgument argument = new AssaultException.ExceptionArgument();
+            argument.setClassName(argumentClass);
+            argument.setValue(argumentValue);
+            assaultException.setArguments(Collections.singletonList(argument));
+        }
+
+        return assaultException;
     }
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpointIntTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpointIntTest.java
@@ -16,10 +16,7 @@
 
 package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
-import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
-import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperties;
-import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
-import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import de.codecentric.spring.boot.chaos.monkey.configuration.*;
 import de.codecentric.spring.boot.demo.chaos.monkey.ChaosDemoApplication;
 import org.junit.Before;
 import org.junit.Test;
@@ -128,6 +125,8 @@ public class ChaosMonkeyRestEndpointIntTest {
         assaultProperties.setLatencyRangeEnd(100);
         assaultProperties.setLatencyRangeStart(200);
         assaultProperties.setLatencyActive(true);
+        assaultProperties.setExceptionsActive(false);
+        assaultProperties.setException(new AssaultException());
 
         ResponseEntity<String> result =
                 testRestTemplate.postForEntity(baseUrl + "/assaults", assaultProperties, String.class);
@@ -168,6 +167,25 @@ public class ChaosMonkeyRestEndpointIntTest {
         assaultProperties.setLevel(1000);
         assaultProperties.setLatencyRangeEnd(200);
         assaultProperties.setLatencyActive(true);
+
+        ResponseEntity<String> result =
+                testRestTemplate.postForEntity(baseUrl + "/assaults", assaultProperties, String.class);
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+    }
+
+    @Test
+    public void postAssaultConfigurationBadCaseInvalidExceptionType() {
+        AssaultException exception = new AssaultException();
+        exception.setType("SomeInvalidException");
+
+        AssaultProperties assaultProperties = new AssaultProperties();
+        assaultProperties.setLevel(10);
+        assaultProperties.setLatencyRangeEnd(100);
+        assaultProperties.setLatencyRangeStart(200);
+        assaultProperties.setLatencyActive(true);
+        assaultProperties.setExceptionsActive(false);
+        assaultProperties.setException(exception);
 
         ResponseEntity<String> result =
                 testRestTemplate.postForEntity(baseUrl + "/assaults", assaultProperties, String.class);

--- a/chaos-monkey-spring-boot/src/test/resources/application-test-chaos-monkey-profile.properties
+++ b/chaos-monkey-spring-boot/src/test/resources/application-test-chaos-monkey-profile.properties
@@ -19,6 +19,9 @@ chaos.monkey.watcher.controller=true
 chaos.monkey.assaults.level=1
 chaos.monkey.assaults.latency-range-end=50
 chaos.monkey.assaults.latency-range-start=10
+chaos.monkey.assaults.exception.type=java.lang.RuntimeException
+chaos.monkey.assaults.exception.arguments[0].className=java.lang.String
+chaos.monkey.assaults.exception.arguments[0].value='test string'
 # enable Chaos Monkey endpoint
 management.endpoint.chaosmonkey.enabled=true
 management.endpoints.web.exposure.include=chaosmonkey


### PR DESCRIPTION
Signed-off-by: singhgarima <igarimasingh@gmail.com>

**Changes**:
The pull request enables user to inject custom exceptions. This is a useful case when people are trying to inject failures pertaining to services which through specific exceptions.

**Related Issue**:
#59 

**Specification**:

* Default Behavior: Throw RuntimeException with message "Chaos Monkey - RuntimeException"

* Define Custom exception via properties: `chaos.monkey.assaults.exception.type=java.lang.RuntimeException`

* Define Custom exception with arguments via properties:
```
chaos.monkey.assaults.exception.type=java.lang.RuntimeException
chaos.monkey.assaults.exception.arguments[0].className=java.lang.String
chaos.monkey.assaults.exception.arguments[0].value='test string'
```

* Define custom exception via assaults API:

```
{
  "level": 1,
  "latencyRangeStart": 1000,
  "latencyRangeEnd": 4500,
  "latencyActive": false,
  "exceptionsActive": true,
  "exception": {
    "type": "java.lang.RuntimeException",
    "arguments": [
      {
        "className": "java.lang.String",
        "value": "'Chaos Monkey inject runtime exception'"
      }
    ]
  },
  "killApplicationActive": false
}
```

