### PR TITLE
fixes #61, both rest-controller and restController are valid now

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerCondition.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerCondition.java
@@ -29,7 +29,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 public class AttackRestControllerCondition implements Condition {
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         return context.getEnvironment()
-                .getProperty("chaos.monkey.watcher.restController", "false")
+                .getProperty("chaos.monkey.watcher.rest-controller", "false")
                 .matches("(?i:.*true*)");
     }
 }


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#externalized-configuration - "...Environment takes care of that automatically: env.getProperty("com.foo.my-bar") will find a com.foo.myBar property."