### PR TITLE
fixes #61, both rest-controller and restController are possible to fetch now

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerCondition.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerCondition.java
@@ -29,7 +29,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 public class AttackRestControllerCondition implements Condition {
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         return context.getEnvironment()
-                .getProperty("chaos.monkey.watcher.restController", "false")
+                .getProperty("chaos.monkey.watcher.rest-controller", "false")
                 .matches("(?i:.*true*)");
     }
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerConditionTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/conditions/AttackRestControllerConditionTest.java
@@ -31,7 +31,7 @@ import static org.mockito.BDDMockito.given;
 @RunWith(MockitoJUnitRunner.class)
 public class AttackRestControllerConditionTest {
 
-    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.restController";
+    private final String CHAOS_MONKEY_CONTROL_CONDITION = "chaos.monkey.watcher.rest-controller";
     private final String FALSE_DEFAULT = "false";
     private AttackRestControllerCondition attackRestControllerCondition;
     @Mock


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#externalized-configuration - "RelaxedPropertyResolver is no longer available as the Environment takes care of that automatically: env.getProperty("com.foo.my-bar") will find a com.foo.myBar property."