### PR TITLE
Added capability to inject arbitrary exceptions

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssault.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssault.java
@@ -19,7 +19,6 @@ package de.codecentric.spring.boot.chaos.monkey.assaults;
 import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
 import de.codecentric.spring.boot.chaos.monkey.component.MetricType;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
-import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +52,6 @@ public class ExceptionAssault implements ChaosMonkeyAssault {
         if (metricEventPublisher != null)
             metricEventPublisher.publishMetricEvent(MetricType.EXCEPTION_ASSAULT);
 
-        throw assaultException.getExceptionInstance();
+        assaultException.throwExceptionInstance();
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionValidator.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionValidator.java
@@ -16,7 +16,7 @@ public class AssaultExceptionValidator implements ConstraintValidator<AssaultExc
         }
 
         try {
-            Class<? extends RuntimeException> exceptionClass = exception.getExceptionClass();
+            Class<? extends Exception> exceptionClass = exception.getExceptionClass();
             if (exception.getArguments() == null) {
                 exceptionClass.getConstructor();
             } else {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.hamcrest.core.Is.isA;
@@ -95,6 +96,17 @@ public class ExceptionAssaultTest {
         ChaosMonkeySettings settings = getChaosMonkeySettings();
         settings.getAssaultProperties().setException(
                 getAssaultException("java.lang.ArithmeticException", exceptionArgumentClassName, exceptionArgumentValue));
+
+        ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+        exceptionAssault.attack();
+    }
+
+    @Test
+    public void throwsGeneralException() {
+        exception.expect(isA(IOException.class));
+
+        ChaosMonkeySettings settings = getChaosMonkeySettings();
+        settings.getAssaultProperties().setException(getAssaultException("java.io.IOException", null, null));
 
         ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
         exceptionAssault.attack();


### PR DESCRIPTION
Previously, we were limited to specifying subtypes of RuntimeException,
but since the VM does not actually enforce this constraint, we
can accept arbitrary constraints instead