### PR TITLE
fix runChaos.sh package version

### DIFF
--- a/demo-apps/chaos-monkey-demo-app-ext-jar/runChaos.sh
+++ b/demo-apps/chaos-monkey-demo-app-ext-jar/runChaos.sh
@@ -1,1 +1,1 @@
-java -cp ./target/chaos-monkey-demo-app-ext-jar-2.0.1-SNAPSHOT.jar -Dloader.path=../../chaos-monkey-spring-boot/target/chaos-monkey-spring-boot-2.0.1-SNAPSHOT-jar-with-dependencies.jar org.springframework.boot.loader.PropertiesLauncher --spring.profiles.active=chaos-monkey
+java -cp ./target/chaos-monkey-demo-app-ext-jar-2.0.2.jar -Dloader.path=../../chaos-monkey-spring-boot/target/chaos-monkey-spring-boot-2.0.2-jar-with-dependencies.jar org.springframework.boot.loader.PropertiesLauncher --spring.profiles.active=chaos-monkey


### PR DESCRIPTION
command does not work for current package when I try this demo.
update it to fit current version.