### PR TITLE
Make tests run with Java 12 (by getting rid of powermock)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - openjdk12
 sudo: false # faster builds
 
 after_success:

--- a/chaos-monkey-dependencies/pom.xml
+++ b/chaos-monkey-dependencies/pom.xml
@@ -114,20 +114,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito-all.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/chaos-monkey-spring-boot/dependency-reduced-pom.xml
+++ b/chaos-monkey-spring-boot/dependency-reduced-pom.xml
@@ -121,41 +121,9 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>3.0.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>powermock-api-mockito-common</artifactId>
-          <groupId>org.powermock</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>mockito-core</artifactId>
-          <groupId>org.mockito</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>powermock-module-junit4-common</artifactId>
-          <groupId>org.powermock</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>hamcrest-core</artifactId>
-          <groupId>org.hamcrest</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -77,17 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ChaosMonkeyLatencyAssaultExecutor.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/ChaosMonkeyLatencyAssaultExecutor.java
@@ -1,0 +1,6 @@
+package de.codecentric.spring.boot.chaos.monkey.assaults;
+
+public interface ChaosMonkeyLatencyAssaultExecutor {
+
+    void execute(long duration);
+}

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssault.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssault.java
@@ -33,15 +33,21 @@ public class LatencyAssault implements ChaosMonkeyRequestAssault {
     private static final Logger LOGGER = LoggerFactory.getLogger(LatencyAssault.class);
 
     private final ChaosMonkeySettings settings;
+    private final ChaosMonkeyLatencyAssaultExecutor assaultExecutor;
 
     private MetricEventPublisher metricEventPublisher;
 
     private AtomicInteger atomicTimeoutGauge;
 
-    public LatencyAssault(ChaosMonkeySettings settings, MetricEventPublisher metricEventPublisher) {
+    public LatencyAssault(ChaosMonkeySettings settings, MetricEventPublisher metricEventPublisher, ChaosMonkeyLatencyAssaultExecutor executor) {
         this.settings = settings;
         this.metricEventPublisher = metricEventPublisher;
         this.atomicTimeoutGauge = new AtomicInteger(0);
+        this.assaultExecutor = executor;
+    }
+
+    public LatencyAssault(ChaosMonkeySettings settings, MetricEventPublisher metricEventPublisher){
+        this(settings, metricEventPublisher, new LatencyAssaultExecutor());
     }
 
     @Override
@@ -61,11 +67,7 @@ public class LatencyAssault implements ChaosMonkeyRequestAssault {
             metricEventPublisher.publishMetricEvent(MetricType.LATENCY_ASSAULT, atomicTimeoutGauge);
         }
 
-        try {
-            Thread.sleep(atomicTimeoutGauge.get());
-        } catch (InterruptedException e) {
-            // do nothing
-        }
+        assaultExecutor.execute(atomicTimeoutGauge.get());
     }
 
     private int determineLatency() {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultExecutor.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultExecutor.java
@@ -1,0 +1,12 @@
+package de.codecentric.spring.boot.chaos.monkey.assaults;
+
+public class LatencyAssaultExecutor implements ChaosMonkeyLatencyAssaultExecutor {
+    @Override
+    public void execute(long durationInMillis) {
+        try {
+            Thread.sleep(durationInMillis);
+        } catch (InterruptedException e) {
+            // do nothing
+        }
+    }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/KillAppAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/KillAppAssaultTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/KillAppAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/KillAppAssaultTest.java
@@ -47,9 +47,8 @@ public class KillAppAssaultTest {
     private MetricEventPublisher metricsMock;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-        when(mockAppender.getName()).thenReturn("MOCK");
         root.addAppender(mockAppender);
 
         captorLoggingEvent = ArgumentCaptor.forClass(LoggingEvent.class);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultRangeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultRangeTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -20,8 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultRangeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultRangeTest.java
@@ -22,11 +22,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LatencyAssaultRangeTest {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/LatencyAssaultTest.java
@@ -53,8 +53,9 @@ public class LatencyAssaultTest {
         latencyAssault.attack();
 
         assertTrue(executor.executed);
-        assertTrue(executor.duration > latencyRangeStart);
-        assertTrue(executor.duration < latencyRangeEnd);
+        String assertionMessage = "Latency not in range 100-200, actual latency: " +executor.duration;
+        assertTrue(assertionMessage, executor.duration >= latencyRangeStart);
+        assertTrue(assertionMessage,executor.duration <= latencyRangeEnd);
     }
 
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -143,7 +143,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void isExceptionActiveExpectExceptionAttack() {
         given(exceptionAssault.isActive()).willReturn(true);
         given(latencyAssault.isActive()).willReturn(false);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -155,7 +154,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void isLatencyActiveExpectLatencyAttack() {
         given(exceptionAssault.isActive()).willReturn(false);
         given(latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -196,7 +194,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
         String customService = "CustomService";
 
-        given(exceptionAssault.isActive()).willReturn(true);
         given(this.assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
         given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -172,7 +172,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void givenAssaultLevelTooHighExpectNoLogging() {
         given(this.assaultProperties.getLevel()).willReturn(1000);
         given(this.assaultProperties.getTroubleRandom()).willReturn(9);
-        given(this.latencyAssault.isActive()).willReturn(true);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -56,9 +56,6 @@ public class ChaosMonkeyRequestScopeTest {
     private ExceptionAssault exceptionAssault;
 
     @Mock
-    private KillAppAssault killAppAssault;
-
-    @Mock
     private MemoryAssault memoryAssaultMock;
 
     @Mock
@@ -80,7 +77,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void allAssaultsActiveExpectLatencyAttack() {
         given(this.exceptionAssault.isActive()).willReturn(true);
         given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -92,7 +88,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void allAssaultsActiveExpectExceptionAttack() {
         given(this.exceptionAssault.isActive()).willReturn(true);
         given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(1);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -105,7 +100,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void isLatencyAssaultActive() {
         given(this.latencyAssault.isActive()).willReturn(true);
         given(this.exceptionAssault.isActive()).willReturn(false);
-        given(this.killAppAssault.isActive()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -116,7 +110,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void isExceptionAssaultActive() {
         given(this.exceptionAssault.isActive()).willReturn(true);
         given(this.latencyAssault.isActive()).willReturn(false);
-        given(this.killAppAssault.isActive()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -127,7 +120,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void isExceptionAndLatencyAssaultActiveExpectExceptionAttack() {
         given(this.exceptionAssault.isActive()).willReturn(true);
         given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.killAppAssault.isActive()).willReturn(false);
         given(this.assaultProperties.chooseAssault(2)).willReturn(1);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -140,7 +132,6 @@ public class ChaosMonkeyRequestScopeTest {
 
         given(this.exceptionAssault.isActive()).willReturn(true);
         given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.killAppAssault.isActive()).willReturn(false);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -149,10 +140,9 @@ public class ChaosMonkeyRequestScopeTest {
     }
 
     @Test
-    public void isExceptionAndKillAssaultActiveExpectExceptionAttack() {
+    public void isExceptionActiveExpectExceptionAttack() {
         given(exceptionAssault.isActive()).willReturn(true);
         given(latencyAssault.isActive()).willReturn(false);
-        given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -162,10 +152,9 @@ public class ChaosMonkeyRequestScopeTest {
 
 
     @Test
-    public void isLatencyAndKillAssaultActiveExpectLatencyAttack() {
+    public void isLatencyActiveExpectLatencyAttack() {
         given(exceptionAssault.isActive()).willReturn(false);
         given(latencyAssault.isActive()).willReturn(true);
-        given(this.killAppAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -175,15 +164,10 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void givenNoAssaultsActiveExpectNoAttack() {
-        given(exceptionAssault.isActive()).willReturn(false);
-        given(latencyAssault.isActive()).willReturn(false);
-        given(killAppAssault.isActive()).willReturn(false);
-
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
-        verify(killAppAssault, never()).attack();
     }
 
     @Test
@@ -196,7 +180,6 @@ public class ChaosMonkeyRequestScopeTest {
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
-        verify(killAppAssault, never()).attack();
     }
 
     @Test
@@ -207,7 +190,6 @@ public class ChaosMonkeyRequestScopeTest {
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
-        verify(killAppAssault, never()).attack();
     }
 
     @Test
@@ -215,15 +197,13 @@ public class ChaosMonkeyRequestScopeTest {
         String customService = "CustomService";
 
         given(exceptionAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Arrays.asList(customService));
+        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
         given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
 
         chaosMonkeyRequestScope.callChaosMonkey("notInListService");
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
-        verify(killAppAssault, never()).attack();
-
     }
 
     @Test
@@ -231,7 +211,7 @@ public class ChaosMonkeyRequestScopeTest {
         String customService = "CustomService";
 
         given(exceptionAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Arrays.asList(customService));
+        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
         given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
         given(latencyAssault.isActive()).willReturn(true);
         given(this.assaultProperties.chooseAssault(2)).willReturn(0);
@@ -240,7 +220,6 @@ public class ChaosMonkeyRequestScopeTest {
 
         verify(latencyAssault, times(1)).attack();
         verify(exceptionAssault, never()).attack();
-        verify(killAppAssault, never()).attack();
     }
 
     @Test

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -24,11 +24,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
@@ -7,13 +7,13 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
@@ -1,16 +1,13 @@
 package de.codecentric.spring.boot.chaos.monkey.component;
 
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
@@ -18,11 +15,9 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ScheduledTask.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ChaosMonkeySchedulerTest {
     @Mock
     private ScheduledTaskRegistrar registrar;
@@ -79,7 +74,7 @@ public class ChaosMonkeySchedulerTest {
         String schedule = "*/1 * * * * ?";
         when(config.getRuntimeAssaultCronExpression()).thenReturn(schedule);
         when(registrar.scheduleCronTask(any())).thenAnswer(iom -> {
-            iom.getArgumentAt(0, CronTask.class).getRunnable().run();
+            iom.getArgument(0, CronTask.class).getRunnable().run();
             return null;
         });
 
@@ -87,19 +82,8 @@ public class ChaosMonkeySchedulerTest {
         verify(scope).callChaosMonkey();
     }
 
-    private Matcher<CronTask> hasScheduleLike(String schedule) {
-        return new BaseMatcher<CronTask>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("has schedule like").appendText(schedule);
-            }
-
-            @Override
-            public boolean matches(Object o) {
-                return ((CronTask) o).getExpression().equals(schedule);
-            }
-        };
+    private ArgumentMatcher<CronTask> hasScheduleLike(String schedule) {
+        return cronTask -> cronTask.getExpression().equals(schedule);
     }
 
     @Before

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectTest.java
@@ -24,7 +24,7 @@ import de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringControllerAspectTest.java
@@ -24,7 +24,7 @@ import de.codecentric.spring.boot.demo.chaos.monkey.controller.DemoController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRepositoryAspectTest.java
@@ -25,7 +25,7 @@ import de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepositoryImp
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringRestControllerAspectTest.java
@@ -24,7 +24,7 @@ import de.codecentric.spring.boot.demo.chaos.monkey.restcontroller.DemoRestContr
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspectTest.java
@@ -24,7 +24,7 @@ import de.codecentric.spring.boot.demo.chaos.monkey.service.DemoService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import static org.mockito.Mockito.*;

--- a/chaos-monkey-spring-boot/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/chaos-monkey-spring-boot/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/demo-apps/chaos-monkey-demo-app-naked/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app-naked/pom.xml
@@ -64,6 +64,11 @@
             <version>${spring-boot.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/demo-apps/chaos-monkey-demo-app/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,7 @@
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <junit.version>4.12</junit.version>
         <assertj-core.version>2.6.0</assertj-core.version>
-        <mockito-all.version>1.10.19</mockito-all.version>
-        <powermock.version>1.7.4</powermock.version>
+        <mockito.version>3.0.0</mockito.version>
         <asciidoctor-maven-plugin.version>1.5.6</asciidoctor-maven-plugin.version>
 
 


### PR DESCRIPTION
Hi there

So this Pull-Request (inspired by https://github.com/codecentric/chaos-monkey-spring-boot/issues/86) does the following things:

- :heavy_minus_sign: Removing powermock(ito) as dependency
- :heavy_minus_sign: :arrow_up: Remove mockito_all ([not produced anymore](url)) with mockito-core and upgraded to latest version (from 1.10 to 3.0)
- :sparkles: Introduced a ChaosMonkeyLatencyAssaultExecutor to get the test LatencyAssaultTest green
- :green_heart: Make Travis run on jdk9-12
- :white_check_mark: :fire: Removed unnecessary stubs (I figured out, that KillAssault is currently not tested in ChaosMonkeyRequestScopeTest and probably should be tested in a new ChaosMonkeyRuntimeScopeTest)


Up so far this PR does not fix the flanky testcase MemoryAssaultIntegrationTest#allowInterruptionOfAssaultDuringHoldPeriod, which sometimes fails.


I would like to have some feedback in following subjects:

1. Introducion of ChaosMonkeyLatencyAssaultExecutor (I dont like the solution that much, if you have a better idea, how to solve it in a cleaner/better way, let me know)
2. I needed to add mockito-core as dependency on the subprojects chaos-monkey-demo-app-naked and chaos-monkey-demo-app. If I remove it we get some classnotfoundexceptions from spring mocking classes (I dont know why thats the case)

~~3. On my local (windows) machine, the test ChaosDemoApplicationTests#checkMetricsBean (of Project chaos-monkey-demo-app-ext-jar only) is failing. On travis (linux) its no problem. Is that the case for you too? Do you have an idea, why the metrics bean could be not available?~~ It fails on current master as well (created #90). 


