### PR TITLE
Fix maven missing plugin version warnings

### DIFF
--- a/chaos-monkey-docs/pom.xml
+++ b/chaos-monkey-docs/pom.xml
@@ -19,6 +19,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
+                <version>${git-commit-id-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -36,6 +37,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>output-html</id>
@@ -80,7 +82,7 @@
                     <plugin>
                         <groupId>com.github.github</groupId>
                         <artifactId>site-maven-plugin</artifactId>
-                        <version>0.12</version>
+                        <version>${site-maven-plugin.version}</version>
                         <configuration>
                             <message>Creating Reference Guide for ${project.version}</message>
                             <path>${project.version}</path>
@@ -100,7 +102,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-project-info-reports-plugin</artifactId>
-                        <version>2.7</version>
+                        <version>${maven-project-info-reports-plugin.version}</version>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
+        <git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>
+        <site-maven-plugin.version>0.12</site-maven-plugin.version>
+        <maven-project-info-reports-plugin.version>2.7</maven-project-info-reports-plugin.version>
 
         <!-- GitHub Server settings.xml -->
         <github.global.server>github</github.global.server>


### PR DESCRIPTION
Fix this maven warning by pinning plugin version, when running `mvn generate-resources` in `chaos-monkey-docs`:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for de.codecentric:chaos-monkey-docs:jar:2.1.0
[WARNING] 'build.plugins.plugin.version' for pl.project13.maven:git-commit-id-plugin is missing. @ de.codecentric:chaos-monkey-docs:${revision}, C:\dev\git\chaos-monkey-spring-boot\chaos-monkey-docs\pom.xml, line 19, column 21
[WARNING] 'build.plugins.plugin.version' for org.asciidoctor:asciidoctor-maven-plugin is missing. @ de.codecentric:chaos-monkey-docs:${revision}, C:\dev\git\chaos-monkey-spring-boot\chaos-monkey-docs\pom.xml, line 36, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```