### PR TITLE
Fix missing maven deploy plugin version warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>
         <maven-project-info-reports-plugin.version>2.7</maven-project-info-reports-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 
         <!-- GitHub Server settings.xml -->
         <github.global.server>github</github.global.server>
@@ -193,6 +194,11 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Declare maven plugin version to avoid warnings seen during `mvn deploy`