### PR TITLE
Fix broken gh-pages readme release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Chaos Monkey for Spring Boot versions will follow the versions of Spring Boot. T
 ## Documentation
 A detailed documentation about the configuration of the Chaos Monkey for Spring Boot can be found here.
 
+<a name="releases"></a>
 ### Chaos Monkey Releases
 - [Version 1.0.1](https://codecentric.github.io/chaos-monkey-spring-boot/1.0.1/)
 - [Version 1.5.0](https://codecentric.github.io/chaos-monkey-spring-boot/1.5.0)


### PR DESCRIPTION
Release TOC broke with commit https://github.com/codecentric/chaos-monkey-spring-boot/commit/c129bcd11cbdf375d4509954706e54ee3541575e