### PR TITLE
Fix #118 by excluding spring.cloud.context in component watcher

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -2,6 +2,7 @@
 == Changes in {project-version}
 
 === Bug Fixes
+https://github.com/codecentric/chaos-monkey-spring-boot/pull/120[#120] Fix `BeanCurrentlyInCreationException` at startup when having Spring Cloud dependencies.
 
 === Improvements
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
@@ -45,9 +45,14 @@ public class SpringComponentAspect extends ChaosMonkeyBaseAspect {
     public void classAnnotatedWithComponentPointcut() {
     }
 
-    @Around("classAnnotatedWithComponentPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
-    public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
+    @Pointcut("within(org.springframework.cloud.context..*)")
+    public void classInSpringCloudContextPackage() {
+    }
 
+
+    @Around("classAnnotatedWithComponentPointcut() && !classInSpringCloudContextPackage() " +
+            "&& allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
+    public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
         if (watcherProperties.isComponent()) {
             log.debug("Watching public method on component class: {}", pjp.getSignature());
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixed Bug #118 
<!-- Why are these changes necessary? -->

**Why**:
Projects which had dependencies to Spring Cloud were unable to start the container after using latest spring boot for chaos monkey (2.1.0)
<!-- How were these changes implemented? -->

**How**:
Excluded package `org.springframework.cloud.context.*` for beeing watched by ChaosMonkeyComponentWatcher (`de.codecentric.spring.boot.chaos.monkey.watcher.SpringComponentAspect`)
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
N/A      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Not sure how to test this in an automated way (we could add spring cloud context as a test dependency, so some tests would not boot).

Problem was that the `org.springframework.cloud.context.properties.ConfigurationPropertiesBeans` is also a Component and triggered `de.codecentric.spring.boot.chaos.monkey.watcher.SpringComponentAspect` which injected a ChaosMonkeyRequestScope and caused the issue.

Thanks and shoutout to @srempfer, @maiksensi, @Pinguwien and @t1, with your help it wouldnt have been possible to fix it 🙏 
