### PR TITLE
Setup next release cycle

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -2,7 +2,6 @@
 == Changes in {project-version}
 
 === Bug Fixes
-https://github.com/codecentric/chaos-monkey-spring-boot/pull/120[#120] Fix `BeanCurrentlyInCreationException` at startup when having Spring Cloud dependencies.
 
 === Improvements
 
@@ -10,7 +9,5 @@ https://github.com/codecentric/chaos-monkey-spring-boot/pull/120[#120] Fix `Bean
 
 === Contributors
 This release was only possible because of these great humans:
-
-- https://www.github.com/WtfJoke[@WtfJoke]
 
 Thank you for your support!

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <!-- project version -->
-        <revision>2.1.1</revision>
+        <revision>2.2.0-SNAPSHOT</revision>
         <!-- default settings -->
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Next release cycle is 2.2.0-SNAPSHOT

- No need to update gh-pages as we already have docs for 2.2.0-SNAPSHOT