### PR TITLE
Fix: CMSB deprecated API usage in MetricEventPublisher

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -1,6 +1,6 @@
 [[changes]]
 == Changes in {project-version}
-
+https://github.com/codecentric/chaos-monkey-spring-boot/pull/131 Deprecated constructor usage removal
 === Bug Fixes
 
 === Improvements
@@ -9,5 +9,7 @@
 
 === Contributors
 This release was only possible because of these great humans:
+
+https://github.com/Abijithkrishna
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
@@ -25,7 +25,8 @@ public class MetricEventPublisher implements ApplicationEventPublisherAware {
     }
 
     public void publishMetricEvent(MetricType metricType, AtomicInteger atomicTimeoutGauge) {
-        MetricEvent metricEvent = new MetricEvent(this, metricType, atomicTimeoutGauge);
+        //MetricEvent constructor has been deprecated. So falling back to the internally used Constructor
+        MetricEvent metricEvent = new MetricEvent(this, metricType, atomicTimeoutGauge!=null? atomicTimeoutGauge.longValue() : -1,null);
         publisher.publishEvent(metricEvent);
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
A deprecated constructor was being used in MetricEventPublisher.
<!-- Why are these changes necessary? -->

**Why**:
A warning would be logged when building, referring to the use of deprecated methods. If left unchecked a compilation issue might occur in the future.
<!-- How were these changes implemented? -->

**How**:
The constructor was replaced by the inner workings of it, (ie) the constructor was internally calling another constructor which has been called directly. 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
