### PR TITLE
fix(#128): MetricPublisher is using a deprecated API

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -6,6 +6,7 @@
 === Improvements
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/127[#127] Update dependencies to latest stable versions.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/130[#130] Improvement 'Improve contributions clarity in README'
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/130[#134] fix(https://github.com/codecentric/chaos-monkey-spring-boot/issues/128[#128]): MetricPublisher is using a deprecated API
 
 === New Features
 
@@ -14,5 +15,6 @@ This release was only possible because of these great humans:
 
 - https://github.com/ultcyber[@ultcyber]
 - https://github.com/Chrispy404[@Chrispy404]
+- https://github.com/basalt79[@basalt79]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
@@ -25,8 +25,7 @@ public class MetricEventPublisher implements ApplicationEventPublisherAware {
     }
 
     public void publishMetricEvent(MetricType metricType, AtomicInteger atomicTimeoutGauge) {
-        MetricEvent metricEvent = new MetricEvent(this, metricType, atomicTimeoutGauge);
-        publisher.publishEvent(metricEvent);
+        this.publishMetricEvent(metricType, atomicTimeoutGauge == null ? -1 : atomicTimeoutGauge.longValue());
     }
 
     @Override


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
A deprecated constructor has been called.

<!-- Why are these changes necessary? -->

**Why**:
The constructor set to deprecated.

<!-- How were these changes implemented? -->

**How**:
By calling an existing method inside the same class.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ N/A ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ X ] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ N/A ] Tests added
      <!-- Thank you so much for that! -->
- [ X ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
