### PR TITLE
Remove deprecated MetricEvent constructor and adapt usage

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -9,6 +9,7 @@
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/127[#127] Update dependencies to latest stable versions.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/130[#130] Improvement 'Improve contributions clarity in README'
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/136[#136] Add example entry in changelog
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/131[#131] Remove deprecated MetricEvent constructor and adapt usage
 
 === New Features
 
@@ -20,5 +21,6 @@ This release was only possible because of these great humans:
 - https://github.com/ultcyber[@ultcyber]
 - https://github.com/Chrispy404[@Chrispy404]
 - https://github.com/Olfarmer[@Olfarmer]
+- https://github.com/Yann-P[@Yann-P]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricEventPublisher.java
@@ -25,7 +25,8 @@ public class MetricEventPublisher implements ApplicationEventPublisherAware {
     }
 
     public void publishMetricEvent(MetricType metricType, AtomicInteger atomicTimeoutGauge) {
-        MetricEvent metricEvent = new MetricEvent(this, metricType, atomicTimeoutGauge);
+        final long gaugeValue = (atomicTimeoutGauge == null) ? -1 : atomicTimeoutGauge.longValue(); 
+        MetricEvent metricEvent = new MetricEvent(this, metricType, gaugeValue, null);
         publisher.publishEvent(metricEvent);
     }
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/events/MetricEvent.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/events/MetricEvent.java
@@ -30,11 +30,6 @@ public class MetricEvent extends ApplicationEvent {
         this(source, metricType, -1, null);
     }
 
-    @Deprecated
-    public MetricEvent(Object source, MetricType metricType, AtomicInteger gaugeValue) {
-        this(source, metricType, gaugeValue == null ? -1 : gaugeValue.longValue(), null);
-    }
-
     public MetricEvent(Object source, MetricType metricType, long metricValue, String methodSignature, String... tags) {
         super(source);
         this.metricType = metricType;


### PR DESCRIPTION
fixes #131

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Remove depreacted constructor (MetricEvent)
- Adapt usages 

<!-- Why are these changes necessary? -->

**Why**:

- Suppress build warning

<!-- How were these changes implemented? -->

**How**:

Externalize condition from MetricEvents to the class that used it (MetricEventPublisher)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
