### PR TITLE
Fix default values for latencyRange in docs

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
@@ -25,12 +25,12 @@ Except for the Watcher, you can also influence the behavior of the Chaos Monkey 
 |chaos.monkey.assaults.latencyRangeStart
 |Minimum latency in ms added to the request
 |Integer.MIN_VALUE, Integer.MAX_VALUE
-|3000
+|1000
 
 |chaos.monkey.assaults.latencyRangeEnd
 |Maximum latency in ms added to the request
 |Integer.MIN_VALUE, Integer.MAX_VALUE
-|15000
+|3000
 
 |chaos.monkey.assaults.latencyActive
 |Latency assault active


### PR DESCRIPTION
Resolves: #138

**What**:
Fix the documented default values of the two properties

- `chaos.monkey.assaults.latencyRangeStart`
- `chaos.monkey.assaults.latencyRangeEnd`


**Why**:
The documentation should be in sync with the implementation

<!-- How were these changes implemented? -->

**How**:

Fixed the docs
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ ] Changelog updated N/A
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
