### PR TITLE
Migrate ChaosMonkeyRequestScopeTest to JUnit Jupiter

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -14,6 +14,7 @@
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/141[#141] Migrate tests to JUnit Jupiter
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/143[#143] Add Maven Wrapper
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/148[#148] Add new aspect for watching non-JPA repositories.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/146[#146] Migrate ChaosMonkeyRequestScopeTest to JUnit Jupiter
 
 === New Features
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -57,9 +57,6 @@ public class ChaosMonkeyRequestScopeTest {
     private ExceptionAssault exceptionAssault;
 
     @Mock
-    private MemoryAssault memoryAssaultMock;
-
-    @Mock
     private MetricEventPublisher metricEventPublisherMock;
 
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -65,20 +65,20 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Before
     public void setUp() {
-        given(this.assaultProperties.getLevel()).willReturn(1);
-        given(this.assaultProperties.getTroubleRandom()).willReturn(1);
-        given(this.chaosMonkeyProperties.isEnabled()).willReturn(true);
-        given(this.chaosMonkeySettings.getAssaultProperties()).willReturn(this.assaultProperties);
-        given(this.chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(this.chaosMonkeyProperties);
+        given(assaultProperties.getLevel()).willReturn(1);
+        given(assaultProperties.getTroubleRandom()).willReturn(1);
+        given(chaosMonkeyProperties.isEnabled()).willReturn(true);
+        given(chaosMonkeySettings.getAssaultProperties()).willReturn(assaultProperties);
+        given(chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(chaosMonkeyProperties);
 
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
     }
 
     @Test
     public void allAssaultsActiveExpectLatencyAttack() {
-        given(this.exceptionAssault.isActive()).willReturn(true);
-        given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(0);
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(latencyAssault.isActive()).willReturn(true);
+        given(assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -87,9 +87,9 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void allAssaultsActiveExpectExceptionAttack() {
-        given(this.exceptionAssault.isActive()).willReturn(true);
-        given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(1);
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(latencyAssault.isActive()).willReturn(true);
+        given(assaultProperties.chooseAssault(2)).willReturn(1);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -99,8 +99,8 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void isLatencyAssaultActive() {
-        given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.exceptionAssault.isActive()).willReturn(false);
+        given(latencyAssault.isActive()).willReturn(true);
+        given(exceptionAssault.isActive()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -109,8 +109,8 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void isExceptionAssaultActive() {
-        given(this.exceptionAssault.isActive()).willReturn(true);
-        given(this.latencyAssault.isActive()).willReturn(false);
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(latencyAssault.isActive()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -119,9 +119,9 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void isExceptionAndLatencyAssaultActiveExpectExceptionAttack() {
-        given(this.exceptionAssault.isActive()).willReturn(true);
-        given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(1);
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(latencyAssault.isActive()).willReturn(true);
+        given(assaultProperties.chooseAssault(2)).willReturn(1);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -131,9 +131,9 @@ public class ChaosMonkeyRequestScopeTest {
     @Test
     public void isExceptionAndLatencyAssaultActiveExpectLatencyAttack() {
 
-        given(this.exceptionAssault.isActive()).willReturn(true);
-        given(this.latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(0);
+        given(exceptionAssault.isActive()).willReturn(true);
+        given(latencyAssault.isActive()).willReturn(true);
+        given(assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -171,8 +171,8 @@ public class ChaosMonkeyRequestScopeTest {
 
     @Test
     public void givenAssaultLevelTooHighExpectNoLogging() {
-        given(this.assaultProperties.getLevel()).willReturn(1000);
-        given(this.assaultProperties.getTroubleRandom()).willReturn(9);
+        given(assaultProperties.getLevel()).willReturn(1000);
+        given(assaultProperties.getTroubleRandom()).willReturn(9);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -184,7 +184,7 @@ public class ChaosMonkeyRequestScopeTest {
     //  in the @BeforeEach method
     @Test
     public void isChaosMonkeyExecutionDisabled() {
-        given(this.chaosMonkeyProperties.isEnabled()).willReturn(false);
+        given(chaosMonkeyProperties.isEnabled()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 
@@ -196,7 +196,7 @@ public class ChaosMonkeyRequestScopeTest {
     public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
         String customService = "CustomService";
 
-        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
+        given(assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
         given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
 
         chaosMonkeyRequestScope.callChaosMonkey("notInListService");
@@ -210,10 +210,10 @@ public class ChaosMonkeyRequestScopeTest {
         String customService = "CustomService";
 
         given(exceptionAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
+        given(assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
         given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
         given(latencyAssault.isActive()).willReturn(true);
-        given(this.assaultProperties.chooseAssault(2)).willReturn(0);
+        given(assaultProperties.chooseAssault(2)).willReturn(0);
 
         chaosMonkeyRequestScope.callChaosMonkey(customService);
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -59,16 +59,19 @@ public class ChaosMonkeyRequestScopeTest {
     @Mock
     private MetricEventPublisher metricEventPublisherMock;
 
+    @Before
+    public void setUpCommon() {
+        given(chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(chaosMonkeyProperties);
+
+        chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
+    }
 
     @Before
-    public void setUp() {
+    public void setUpForChaosMonkeyExecutionEnabled() {
         given(assaultProperties.getLevel()).willReturn(1);
         given(assaultProperties.getTroubleRandom()).willReturn(1);
         given(chaosMonkeyProperties.isEnabled()).willReturn(true);
         given(chaosMonkeySettings.getAssaultProperties()).willReturn(assaultProperties);
-        given(chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(chaosMonkeyProperties);
-
-        chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
     }
 
     // TODO This test fails if the class is annotated with @ExtendWith(MockitoExtension.class) because of unnecessary stubbings

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -37,37 +37,37 @@ import static org.mockito.Mockito.*;
  * @author Benjamin Wilms
  */
 @ExtendWith(MockitoExtension.class)
-public class ChaosMonkeyRequestScopeTest {
+class ChaosMonkeyRequestScopeTest {
 
-    private ChaosMonkeyRequestScope chaosMonkeyRequestScope;
-
-    @Mock
-    private AssaultProperties assaultProperties;
+    ChaosMonkeyRequestScope chaosMonkeyRequestScope;
 
     @Mock
-    private ChaosMonkeyProperties chaosMonkeyProperties;
+    AssaultProperties assaultProperties;
 
     @Mock
-    private ChaosMonkeySettings chaosMonkeySettings;
+    ChaosMonkeyProperties chaosMonkeyProperties;
 
     @Mock
-    private LatencyAssault latencyAssault;
+    ChaosMonkeySettings chaosMonkeySettings;
 
     @Mock
-    private ExceptionAssault exceptionAssault;
+    LatencyAssault latencyAssault;
 
     @Mock
-    private MetricEventPublisher metricEventPublisherMock;
+    ExceptionAssault exceptionAssault;
+
+    @Mock
+    MetricEventPublisher metricEventPublisherMock;
 
     @BeforeEach
-    public void setUpCommon() {
+    void setUpCommon() {
         given(chaosMonkeySettings.getChaosMonkeyProperties()).willReturn(chaosMonkeyProperties);
 
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
     }
 
     @Test
-    public void givenChaosMonkeyExecutionIsDisabledExpectNoInteractions() {
+    void givenChaosMonkeyExecutionIsDisabledExpectNoInteractions() {
         given(chaosMonkeyProperties.isEnabled()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
@@ -80,7 +80,7 @@ public class ChaosMonkeyRequestScopeTest {
     class GivenChaosMonekyExecutionIsEnabled {
 
         @BeforeEach
-        public void setUpForChaosMonkeyExecutionEnabled() {
+        void setUpForChaosMonkeyExecutionEnabled() {
             given(assaultProperties.getLevel()).willReturn(1);
             given(assaultProperties.getTroubleRandom()).willReturn(1);
             given(chaosMonkeyProperties.isEnabled()).willReturn(true);
@@ -88,7 +88,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void allAssaultsActiveExpectLatencyAttack() {
+        void allAssaultsActiveExpectLatencyAttack() {
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(true);
             given(assaultProperties.chooseAssault(2)).willReturn(0);
@@ -99,7 +99,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void allAssaultsActiveExpectExceptionAttack() {
+        void allAssaultsActiveExpectExceptionAttack() {
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(true);
             given(assaultProperties.chooseAssault(2)).willReturn(1);
@@ -110,7 +110,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isLatencyAssaultActive() {
+        void isLatencyAssaultActive() {
             given(latencyAssault.isActive()).willReturn(true);
             given(exceptionAssault.isActive()).willReturn(false);
 
@@ -120,7 +120,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isExceptionAssaultActive() {
+        void isExceptionAssaultActive() {
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(false);
 
@@ -130,7 +130,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isExceptionAndLatencyAssaultActiveExpectExceptionAttack() {
+        void isExceptionAndLatencyAssaultActiveExpectExceptionAttack() {
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(true);
             given(assaultProperties.chooseAssault(2)).willReturn(1);
@@ -141,7 +141,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isExceptionAndLatencyAssaultActiveExpectLatencyAttack() {
+        void isExceptionAndLatencyAssaultActiveExpectLatencyAttack() {
 
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(true);
@@ -153,7 +153,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isExceptionActiveExpectExceptionAttack() {
+        void isExceptionActiveExpectExceptionAttack() {
             given(exceptionAssault.isActive()).willReturn(true);
             given(latencyAssault.isActive()).willReturn(false);
 
@@ -163,7 +163,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void isLatencyActiveExpectLatencyAttack() {
+        void isLatencyActiveExpectLatencyAttack() {
             given(exceptionAssault.isActive()).willReturn(false);
             given(latencyAssault.isActive()).willReturn(true);
 
@@ -173,7 +173,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void givenNoAssaultsActiveExpectNoAttack() {
+        void givenNoAssaultsActiveExpectNoAttack() {
             chaosMonkeyRequestScope.callChaosMonkey(null);
 
             verify(latencyAssault, never()).attack();
@@ -181,7 +181,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void givenAssaultLevelTooHighExpectNoLogging() {
+        void givenAssaultLevelTooHighExpectNoLogging() {
             given(assaultProperties.getLevel()).willReturn(1000);
             given(assaultProperties.getTroubleRandom()).willReturn(9);
 
@@ -192,7 +192,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
+        void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
             String customService = "CustomService";
 
             given(assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
@@ -205,7 +205,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void chaosMonkeyIsCalledWhenServiceNotWatched() {
+        void chaosMonkeyIsCalledWhenServiceNotWatched() {
             String customService = "CustomService";
 
             given(exceptionAssault.isActive()).willReturn(true);
@@ -221,7 +221,7 @@ public class ChaosMonkeyRequestScopeTest {
         }
 
         @Test
-        public void shouldMakeUncategorizedCustomAssaultsRequestScopeByDefault() {
+        void shouldMakeUncategorizedCustomAssaultsRequestScopeByDefault() {
             // create an assault that is neither runtime nor request
             ChaosMonkeyAssault customAssault = mock(ChaosMonkeyAssault.class);
             given(customAssault.isActive()).willReturn(true);

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -71,6 +71,18 @@ public class ChaosMonkeyRequestScopeTest {
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
     }
 
+    // TODO This test fails if the class is annotated with @ExtendWith(MockitoExtension.class) because of unnecessary stubbings
+    //  in the @BeforeEach method
+    @Test
+    public void givenChaosMonkeyExecutionIsDisabledExpectNoInteractions() {
+        given(chaosMonkeyProperties.isEnabled()).willReturn(false);
+
+        chaosMonkeyRequestScope.callChaosMonkey(null);
+
+        verify(latencyAssault, never()).attack();
+        verify(exceptionAssault, never()).attack();
+    }
+
     @Test
     public void allAssaultsActiveExpectLatencyAttack() {
         given(exceptionAssault.isActive()).willReturn(true);
@@ -170,18 +182,6 @@ public class ChaosMonkeyRequestScopeTest {
     public void givenAssaultLevelTooHighExpectNoLogging() {
         given(assaultProperties.getLevel()).willReturn(1000);
         given(assaultProperties.getTroubleRandom()).willReturn(9);
-
-        chaosMonkeyRequestScope.callChaosMonkey(null);
-
-        verify(latencyAssault, never()).attack();
-        verify(exceptionAssault, never()).attack();
-    }
-
-    // TODO This test fails if the class is annotated with @ExtendWith(MockitoExtension.class) because of unnecessary stubbings
-    //  in the @BeforeEach method
-    @Test
-    public void isChaosMonkeyExecutionDisabled() {
-        given(chaosMonkeyProperties.isEnabled()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null);
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -66,16 +66,9 @@ public class ChaosMonkeyRequestScopeTest {
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault), Collections.emptyList(), metricEventPublisherMock);
     }
 
-    @Before
-    public void setUpForChaosMonkeyExecutionEnabled() {
-        given(assaultProperties.getLevel()).willReturn(1);
-        given(assaultProperties.getTroubleRandom()).willReturn(1);
-        given(chaosMonkeyProperties.isEnabled()).willReturn(true);
-        given(chaosMonkeySettings.getAssaultProperties()).willReturn(assaultProperties);
-    }
-
     // TODO This test fails if the class is annotated with @ExtendWith(MockitoExtension.class) because of unnecessary stubbings
     //  in the @BeforeEach method
+
     @Test
     public void givenChaosMonkeyExecutionIsDisabledExpectNoInteractions() {
         given(chaosMonkeyProperties.isEnabled()).willReturn(false);
@@ -84,6 +77,14 @@ public class ChaosMonkeyRequestScopeTest {
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
+    }
+    
+    @Before
+    public void setUpForChaosMonkeyExecutionEnabled() {
+        given(assaultProperties.getLevel()).willReturn(1);
+        given(assaultProperties.getTroubleRandom()).willReturn(1);
+        given(chaosMonkeyProperties.isEnabled()).willReturn(true);
+        given(chaosMonkeySettings.getAssaultProperties()).willReturn(assaultProperties);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Migrate `ChaosMonkeyRequestScopeTest` to JUnit Jupiter.
<!-- Why are these changes necessary? -->

**Why**:

This test was not touched in #141 because the migration to the strict stubbing of Mockito (coming with the use of `@ExtendWith(MockitoExtension.class)`) revealed unnecessary stubbing in one of its test methods.
<!-- How were these changes implemented? -->

**How**:

Splitting the setup code with the relevant stubbings into two methods.
Then moving all the test methods using only one of those setups to a `@Nested` inner class.
See the JUnit documentation (https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested).

Also, this PR is removing unnecessary `this` modifiers and visibility modifiers in the test class.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A
      <!-- Thank you so much for that! -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
