### PR TITLE
Fix #161 - You can configure watcher in runtime see #84

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -6,6 +6,7 @@
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+https://github.com/codecentric/chaos-monkey-spring-boot/pull/163[#163] Fix wrong docs about configuration of watcher at runtime
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -14,5 +15,6 @@
 This release was only possible because of these great humans:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/WtfJoke[@WtfJoke]
 
 Thank you for your support!

--- a/chaos-monkey-docs/src/main/asciidoc/endpoints.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/endpoints.adoc
@@ -41,9 +41,6 @@ management.endpoints.web.exposure.include=health,info,chaosmonkey
 
 |<<watchers,/chaosmonkey/watchers>>
 |Running Watchers configuration.
-
-NOTE: Watcher cannot be changed at runtime, they are Spring AOP components that have to be created when the
-application starts.
 |GET
 
 |<<watcherspost,/chaosmonkey/watchers>>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix #161 
<!-- Why are these changes necessary? -->

**Why**:
Docs are wrong (https://codecentric.github.io/chaos-monkey-spring-boot/2.2.0/#_http_endpoint)
<!-- How were these changes implemented? -->

**How**:
Removing wrong docs
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
