### PR TITLE
Fix #72 - Validate without @Validated annotation

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,6 +3,7 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/174[#174] Fix serialization problem on `/actuator/chaosmonkey` with AssaultProperties
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultPropertyMinMaxValidator.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultPropertyMinMaxValidator.java
@@ -1,0 +1,39 @@
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import lombok.Data;
+
+@Data
+public class AssaultPropertyMinMaxValidator {
+
+  private static final String VALIDATION_ERROR_MESSAGE = "%s needs to be between %s and %s";
+  private final String validationErrorMessage;
+  private final String propertyName;
+  private final boolean isInvalid;
+
+  public AssaultPropertyMinMaxValidator(
+      boolean isInvalid, String propertyName, String validationErrorMessage) {
+    this.propertyName = propertyName;
+    this.validationErrorMessage = validationErrorMessage;
+    this.isInvalid = isInvalid;
+  }
+
+  public static AssaultPropertyMinMaxValidator of(
+      int propertyValue, int min, int max, String propertyName) {
+    if (propertyValue < min || propertyValue > max) {
+      String validationErrorMessage =
+          String.format(VALIDATION_ERROR_MESSAGE, propertyName, min, max);
+      return new AssaultPropertyMinMaxValidator(true, propertyName, validationErrorMessage);
+    }
+    return new AssaultPropertyMinMaxValidator(false, propertyName, "");
+  }
+
+  public static AssaultPropertyMinMaxValidator of(
+      double propertyValue, double min, double max, String propertyName) {
+    if (propertyValue < min || propertyValue > max) {
+      String validationErrorMessage =
+          String.format(VALIDATION_ERROR_MESSAGE, propertyName, min, max);
+      return new AssaultPropertyMinMaxValidator(true, propertyName, validationErrorMessage);
+    }
+    return new AssaultPropertyMinMaxValidator(false, propertyName, "");
+  }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultPropertyMinMaxValidatorTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultPropertyMinMaxValidatorTest.java
@@ -1,0 +1,121 @@
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import static de.codecentric.spring.boot.chaos.monkey.configuration.AssaultPropertyMinMaxValidator.of;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AssaultPropertyMinMaxValidatorTest {
+
+  @Nested
+  class IsInRange {
+    @Test
+    void inBetweenExpectIsValid() {
+      assertThat(of(10, 1, 20, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isMaxExpectIsValid() {
+      assertThat(of(20, 1, 20, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isMinExpectIsValid() {
+      assertThat(of(1, 1, 20, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isErrorMessageEmpty() {
+      assertThat(of(10, 1, 20, "validProp").getValidationErrorMessage().isEmpty()).isTrue();
+    }
+
+    @Test
+    void isPropertyNameEquals() {
+      assertThat(of(10, 1, 20, "validProp").getPropertyName()).isEqualTo("validProp");
+    }
+  }
+
+  @Nested
+  class IsInRangeDecimal {
+    @Test
+    void inBetweenExpectIsValid() {
+      assertThat(of(1.5, 0.9, 1.8, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isMaxExpectIsValid() {
+      assertThat(of(1.8, 0.9, 1.8, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isMinExpectIsValid() {
+      assertThat(of(0.9, 0.9, 1.8, "validProp").isInvalid()).isFalse();
+    }
+
+    @Test
+    void isErrorMessageEmpty() {
+      assertThat(of(0.9, 0.9, 1.8, "validProp").getValidationErrorMessage().isEmpty()).isTrue();
+    }
+
+    @Test
+    void isPropertyNameEquals() {
+      assertThat(of(0.9, 0.9, 1.8, "validProp").getPropertyName()).isEqualTo("validProp");
+    }
+  }
+
+  @Nested
+  class IsOutOfRange {
+
+    private AssaultPropertyMinMaxValidator invalid;
+
+    @BeforeEach
+    void setUp() {
+      invalid = of(11, 1, 10, "invalidProp");
+    }
+
+    @Test
+    void expectIsInvalid() {
+      assertThat(invalid.isInvalid()).isTrue();
+    }
+
+    @Test
+    void isPropertyNameEquals() {
+      assertThat(invalid.getPropertyName()).isEqualTo("invalidProp");
+    }
+
+    @Test
+    void isErrorMessageFilled() {
+      assertThat(invalid.getValidationErrorMessage())
+          .isEqualTo("invalidProp needs to be between 1 and 10");
+    }
+  }
+
+  @Nested
+  class IsOutOfRangeDecimal {
+
+    private AssaultPropertyMinMaxValidator invalid;
+
+    @BeforeEach
+    void setUp() {
+      invalid = of(1.9, 0.9, 1.8, "invalidProp");
+    }
+
+    @Test
+    void expectIsInvalid() {
+      assertThat(invalid.isInvalid()).isTrue();
+    }
+
+    @Test
+    void isPropertyNameEquals() {
+      assertThat(invalid.getPropertyName()).isEqualTo("invalidProp");
+    }
+
+    @Test
+    void isErrorMessageFilled() {
+      assertThat(invalid.getValidationErrorMessage())
+          .isEqualTo("invalidProp needs to be between 0.9 and 1.8");
+    }
+  }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntTest.java
@@ -201,6 +201,17 @@ class ChaosMonkeyRequestScopeRestEndpointIntTest {
   }
 
   @Test
+  void postAssaultConfigurationBadCaseLevelOutOfRange() {
+    AssaultProperties assaultProperties = new AssaultProperties();
+    assaultProperties.setLevel(Integer.MAX_VALUE);
+
+    ResponseEntity<String> result =
+        testRestTemplate.postForEntity(baseUrl + "/assaults", assaultProperties, String.class);
+
+    assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+  }
+
+  @Test
   void postAssaultConfigurationBadCaseLatencyRangeStartEmpty() {
     AssaultProperties assaultProperties = new AssaultProperties();
     assaultProperties.setLevel(1000);


### PR DESCRIPTION
**What**:
Fixes #72 
**Why**:
To be able to use chaos monkey actuator again on certain use cases
**How**:
By removing the `@Validated` annotation and implementing the `Validator` interface directly in order to not have problems de/serializing `AssaultProperties`. 
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation added~~ N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
      <!-- Thank you so much for that! -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Still need figure out, how we can improve the error message handling. `@Min / @Max` provided more meaningful error messages. 