### PR TITLE
rename integration tests

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -10,6 +10,7 @@
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/160[#160] Introduce Google Style Guide
 - https://github.com/codecentric/chaos-monkey-spring-boot/issues/162[#162] Change default configuration to everything off and predictable values
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/175[#175] Because https://github.com/codecentric/chaos-monkey-spring-boot/pull/160[#160] failed horribly regarding ease of development, introduce spotless instead
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/177[#177] Harmonize test naming.
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -21,5 +22,6 @@ This release was only possible because of these great humans:
 - https://github.com/maiksensi[@maiksensi]
 - https://github.com/WtfJoke[@WtfJoke]
 - https://github.com/fletchgqc[@fletchgqc]
+- https://github.com/Glosur[@glosur]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosMonkeyRequestScopeProfileIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosMonkeyRequestScopeProfileIntegration.java
@@ -50,7 +50,7 @@ import org.springframework.boot.test.context.SpringBootTest;
     "spring.profiles.active=chaos-monkey"
   }
 )
-class ChaosDemoApplicationChaosMonkeyRequestScopeProfileTest {
+class ChaosMonkeyRequestScopeProfileIntegration {
 
   @Autowired private ChaosMonkeyRequestScope chaosMonkeyRequestScope;
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/DefaultProfileIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/DefaultProfileIntegration.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.TestPropertySource;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @TestPropertySource("classpath:application-test-default-profile.properties")
-class ChaosDemoApplicationDefaultProfileTest {
+class DefaultProfileIntegration {
 
   @Autowired(required = false)
   private ChaosMonkeyRequestScope chaosMonkeyRequestScope;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/MemoryAssaultIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/MemoryAssaultIntegration.java
@@ -52,7 +52,7 @@ import org.springframework.http.ResponseEntity;
     "spring.profiles.active=chaos-monkey"
   }
 )
-class MemoryAssaultIntegrationTest {
+class MemoryAssaultIntegration {
 
   @LocalServerPort private int serverPort;
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointDisabledIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointDisabledIntegration.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.TestPropertySource;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @TestPropertySource("classpath:test-chaos-monkey-endpoints-disabled.properties")
-class ChaosMonkeyRequestScopeRestEndpointDisabledIntTest {
+class ChaosMonkeyRequestScopeRestEndpointDisabledIntegration {
 
   @LocalServerPort private int serverPort;
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
@@ -45,7 +45,7 @@ import org.springframework.test.context.TestPropertySource;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @TestPropertySource("classpath:application-test-chaos-monkey-profile.properties")
-class ChaosMonkeyRequestScopeRestEndpointIntTest {
+class ChaosMonkeyRequestScopeRestEndpointIntegration {
 
   @LocalServerPort private int serverPort;
 


### PR DESCRIPTION
Follow [TestName]Integration, as JUnit5 allow for naming ending by
something else than test


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: #165 

<!-- Why are these changes necessary? -->

**Why**: Harmonize test naming

<!-- How were these changes implemented? -->

**How**: Renamed specified tests

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [NA] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [NA] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [NA] Tests added
      <!-- Thank you so much for that! -->
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

