### PR TITLE
Fix #72 - Serializing issue with spring cloud dependencies

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,6 +3,7 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/180[#180] Fixes serialization issues when using actuator combined with spring cloud dependencies (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/72[#72] for more details)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -17,6 +17,8 @@
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.AssaultPropertiesUpdate;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.validation.constraints.DecimalMax;
@@ -115,5 +117,10 @@ public class AssaultProperties {
   @JsonIgnore
   public boolean isWatchedCustomServicesActive() {
     return !CollectionUtils.isEmpty(watchedCustomServices);
+  }
+
+  public AssaultPropertiesUpdate toDto() {
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.convertValue(this, AssaultPropertiesUpdate.class);
   }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeySettings.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeySettings.java
@@ -16,6 +16,7 @@
 
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
+import de.codecentric.spring.boot.chaos.monkey.endpoints.ChaosMonkeySettingsDto;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,4 +35,8 @@ public class ChaosMonkeySettings {
   @NotNull private AssaultProperties assaultProperties;
 
   @NotNull private WatcherProperties watcherProperties;
+
+  public ChaosMonkeySettingsDto toDto() {
+    return new ChaosMonkeySettingsDto(chaosMonkeyProperties, assaultProperties, watcherProperties);
+  }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
@@ -2,12 +2,9 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
-import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultExceptionConstraint;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import java.util.List;
 import java.util.function.Consumer;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import lombok.Data;
@@ -15,60 +12,47 @@ import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 
+
+/**
+ * Is used to update properties. Partial updates are allowed:
+ * i. e. {@code {"level": 2}} is fine.
+ * This is also why we're using ObjectTypes (and not the corresponding primitives).
+ **/
 @Data
 @NoArgsConstructor
 @Validated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssaultPropertiesUpdate {
-
   @Nullable
   @Min(value = 1)
   @Max(value = 10000)
   private Integer level;
 
-  @Nullable
-  @Min(value = 1)
-  @Max(value = Integer.MAX_VALUE)
   private Integer latencyRangeStart;
 
-  @Nullable
-  @Min(value = 1)
-  @Max(value = Integer.MAX_VALUE)
   private Integer latencyRangeEnd;
 
-  @Nullable private Boolean latencyActive;
+  private Boolean latencyActive;
 
-  @Nullable private Boolean exceptionsActive;
+  private Boolean exceptionsActive;
 
-  @AssaultExceptionConstraint private AssaultException exception;
+  private AssaultException exception;
 
-  @Nullable private Boolean killApplicationActive;
+  private Boolean killApplicationActive;
 
-  @Nullable private volatile Boolean memoryActive;
+  private volatile Boolean memoryActive;
 
-  @Nullable
-  @Min(value = 1500)
-  @Max(value = Integer.MAX_VALUE)
   private Integer memoryMillisecondsHoldFilledMemory;
 
-  @Nullable
-  @Min(value = 100)
-  @Max(value = 30000)
   private Integer memoryMillisecondsWaitNextIncrease;
 
-  @Nullable
-  @DecimalMax("1.0")
-  @DecimalMin("0.0")
   private Double memoryFillIncrementFraction;
 
-  @Nullable
-  @DecimalMax("0.95")
-  @DecimalMin("0.05")
   private Double memoryFillTargetFraction;
 
-  @Nullable private String runtimeAssaultCronExpression;
+  private String runtimeAssaultCronExpression;
 
-  @Nullable private List<String> watchedCustomServices;
+  private List<String> watchedCustomServices;
 
   private <T> void applyTo(T value, Consumer<T> setter) {
     if (value != null) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
@@ -15,11 +15,10 @@ import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 
-
 /**
  * Is used to update properties. Partial updates are allowed: i. e. {@code {"level": 2}} is fine.
  * This is also why we're using ObjectTypes (and not the corresponding primitives).
- **/
+ */
 @Data
 @NoArgsConstructor
 @Validated
@@ -40,20 +39,15 @@ public class AssaultPropertiesUpdate {
   @Max(value = Integer.MAX_VALUE)
   private Integer latencyRangeEnd;
 
-  @Nullable
-  private Boolean latencyActive;
+  @Nullable private Boolean latencyActive;
 
-  @Nullable
-  private Boolean exceptionsActive;
+  @Nullable private Boolean exceptionsActive;
 
-  @AssaultExceptionConstraint
-  private AssaultException exception;
+  @AssaultExceptionConstraint private AssaultException exception;
 
-  @Nullable
-  private Boolean killApplicationActive;
+  @Nullable private Boolean killApplicationActive;
 
-  @Nullable
-  private volatile Boolean memoryActive;
+  @Nullable private volatile Boolean memoryActive;
 
   @Nullable
   @Min(value = 1500)
@@ -75,11 +69,9 @@ public class AssaultPropertiesUpdate {
   @DecimalMin("0.05")
   private Double memoryFillTargetFraction;
 
-  @Nullable
-  private String runtimeAssaultCronExpression;
+  @Nullable private String runtimeAssaultCronExpression;
 
-  @Nullable
-  private List<String> watchedCustomServices;
+  @Nullable private List<String> watchedCustomServices;
 
   private <T> void applyTo(T value, Consumer<T> setter) {
     if (value != null) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
@@ -2,9 +2,12 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultExceptionConstraint;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import java.util.List;
 import java.util.function.Consumer;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import lombok.Data;
@@ -14,8 +17,7 @@ import org.springframework.validation.annotation.Validated;
 
 
 /**
- * Is used to update properties. Partial updates are allowed:
- * i. e. {@code {"level": 2}} is fine.
+ * Is used to update properties. Partial updates are allowed: i. e. {@code {"level": 2}} is fine.
  * This is also why we're using ObjectTypes (and not the corresponding primitives).
  **/
 @Data
@@ -28,30 +30,55 @@ public class AssaultPropertiesUpdate {
   @Max(value = 10000)
   private Integer level;
 
+  @Nullable
+  @Min(value = 1)
+  @Max(value = Integer.MAX_VALUE)
   private Integer latencyRangeStart;
 
+  @Nullable
+  @Min(value = 1)
+  @Max(value = Integer.MAX_VALUE)
   private Integer latencyRangeEnd;
 
+  @Nullable
   private Boolean latencyActive;
 
+  @Nullable
   private Boolean exceptionsActive;
 
+  @AssaultExceptionConstraint
   private AssaultException exception;
 
+  @Nullable
   private Boolean killApplicationActive;
 
+  @Nullable
   private volatile Boolean memoryActive;
 
+  @Nullable
+  @Min(value = 1500)
+  @Max(value = Integer.MAX_VALUE)
   private Integer memoryMillisecondsHoldFilledMemory;
 
+  @Nullable
+  @Min(value = 100)
+  @Max(value = 30000)
   private Integer memoryMillisecondsWaitNextIncrease;
 
+  @Nullable
+  @DecimalMax("1.0")
+  @DecimalMin("0.0")
   private Double memoryFillIncrementFraction;
 
+  @Nullable
+  @DecimalMax("0.95")
+  @DecimalMin("0.05")
   private Double memoryFillTargetFraction;
 
+  @Nullable
   private String runtimeAssaultCronExpression;
 
+  @Nullable
   private List<String> watchedCustomServices;
 
   private <T> void applyTo(T value, Consumer<T> setter) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
@@ -34,32 +34,32 @@ public class ChaosMonkeyJmxEndpoint {
   }
 
   @ReadOperation
-  public AssaultProperties getAssaultProperties() {
-    return chaosMonkeySettings.getAssaultProperties();
+  public AssaultPropertiesUpdate getAssaultProperties() {
+    return chaosMonkeySettings.getAssaultProperties().toDto();
   }
 
   @WriteOperation
   public String toggleLatencyAssault() {
     this.chaosMonkeySettings
         .getAssaultProperties()
-        .setLatencyActive(!this.getAssaultProperties().isLatencyActive());
-    return String.valueOf(this.getAssaultProperties().isLatencyActive());
+        .setLatencyActive(!this.getAssaultProperties().getLatencyActive());
+    return String.valueOf(this.getAssaultProperties().getLatencyActive());
   }
 
   @WriteOperation
   public String toggleExceptionAssault() {
     this.chaosMonkeySettings
         .getAssaultProperties()
-        .setExceptionsActive(!this.getAssaultProperties().isExceptionsActive());
-    return String.valueOf(this.getAssaultProperties().isExceptionsActive());
+        .setExceptionsActive(!this.getAssaultProperties().getExceptionsActive());
+    return String.valueOf(this.getAssaultProperties().getExceptionsActive());
   }
 
   @WriteOperation
   public String toggleKillApplicationAssault() {
     this.chaosMonkeySettings
         .getAssaultProperties()
-        .setKillApplicationActive(!this.getAssaultProperties().isKillApplicationActive());
-    return String.valueOf(this.getAssaultProperties().isKillApplicationActive());
+        .setKillApplicationActive(!this.getAssaultProperties().getKillApplicationActive());
+    return String.valueOf(this.getAssaultProperties().getKillApplicationActive());
   }
 
   @ReadOperation()

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
@@ -16,7 +16,6 @@
 
 package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
-import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -18,10 +18,10 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyRuntimeScope;
 import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyScheduler;
-import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -48,11 +48,10 @@ public class ChaosMonkeyRestEndpoint {
   }
 
   @PostMapping("/assaults")
-  public ResponseEntity<String> updateAssaultProperties(
+  public ResponseEntity<?> updateAssaultProperties(
       @RequestBody @Validated AssaultPropertiesUpdate assaultProperties) {
     assaultProperties.applyTo(chaosMonkeySettings.getAssaultProperties());
     scheduler.reloadConfig();
-
     return ResponseEntity.ok().body("Assault config has changed");
   }
 
@@ -63,8 +62,8 @@ public class ChaosMonkeyRestEndpoint {
   }
 
   @GetMapping("/assaults")
-  public AssaultProperties getAssaultSettings() {
-    return this.chaosMonkeySettings.getAssaultProperties();
+  public AssaultPropertiesUpdate getAssaultSettings() {
+    return this.chaosMonkeySettings.getAssaultProperties().toDto();
   }
 
   @PostMapping("/enable")
@@ -80,8 +79,8 @@ public class ChaosMonkeyRestEndpoint {
   }
 
   @GetMapping
-  public ChaosMonkeySettings status() {
-    return this.chaosMonkeySettings;
+  public ChaosMonkeySettingsDto status() {
+    return this.chaosMonkeySettings.toDto();
   }
 
   @GetMapping("/status")

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -48,7 +48,7 @@ public class ChaosMonkeyRestEndpoint {
   }
 
   @PostMapping("/assaults")
-  public ResponseEntity<?> updateAssaultProperties(
+  public ResponseEntity<String> updateAssaultProperties(
       @RequestBody @Validated AssaultPropertiesUpdate assaultProperties) {
     assaultProperties.applyTo(chaosMonkeySettings.getAssaultProperties());
     scheduler.reloadConfig();

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -21,7 +21,6 @@ import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyScheduler;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeySettingsDto.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeySettingsDto.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package de.codecentric.spring.boot.chaos.monkey.endpoints;
+
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
+import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperties;
+import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ChaosMonkeySettingsDto {
+
+  ChaosMonkeyProperties chaosMonkeyProperties;
+  AssaultPropertiesUpdate assaultProperties;
+  WatcherProperties watcherProperties;
+
+  public ChaosMonkeySettingsDto(
+      @NotNull ChaosMonkeyProperties chaosMonkeyProperties,
+      @NotNull AssaultProperties assaultProperties,
+      @NotNull WatcherProperties watcherProperties) {
+    this.chaosMonkeyProperties = chaosMonkeyProperties;
+    this.assaultProperties = assaultProperties.toDto();
+    this.watcherProperties = watcherProperties;
+  }
+}

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/WatcherPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/WatcherPropertiesUpdate.java
@@ -6,11 +6,9 @@ import java.util.function.Consumer;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
-import org.springframework.validation.annotation.Validated;
 
 @Data
 @NoArgsConstructor
-@Validated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WatcherPropertiesUpdate {
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -64,7 +64,7 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
 
     chaosMonkeyJmxEndpoint.toggleLatencyAssault();
 
-    assertThat(chaosMonkeyJmxEndpoint.getAssaultProperties().isLatencyActive(), not(latencyActive));
+    assertThat(chaosMonkeyJmxEndpoint.getAssaultProperties().getLatencyActive(), not(latencyActive));
   }
 
   @Test
@@ -73,7 +73,7 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
     chaosMonkeyJmxEndpoint.toggleExceptionAssault();
 
     assertThat(
-        chaosMonkeyJmxEndpoint.getAssaultProperties().isExceptionsActive(), not(exceptionsActive));
+        chaosMonkeyJmxEndpoint.getAssaultProperties().getExceptionsActive(), not(exceptionsActive));
   }
 
   @Test
@@ -83,7 +83,7 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
     chaosMonkeyJmxEndpoint.toggleKillApplicationAssault();
 
     assertThat(
-        chaosMonkeyJmxEndpoint.getAssaultProperties().isKillApplicationActive(),
+        chaosMonkeyJmxEndpoint.getAssaultProperties().getKillApplicationActive(),
         not(killApplicationActive));
   }
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -55,7 +55,7 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
 
     assertThat(
         chaosMonkeyJmxEndpoint.getAssaultProperties(),
-        is(chaosMonkeySettings.getAssaultProperties()));
+        is(chaosMonkeySettings.getAssaultProperties().toDto()));
   }
 
   @Test

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -64,7 +64,8 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
 
     chaosMonkeyJmxEndpoint.toggleLatencyAssault();
 
-    assertThat(chaosMonkeyJmxEndpoint.getAssaultProperties().getLatencyActive(), not(latencyActive));
+    assertThat(
+        chaosMonkeyJmxEndpoint.getAssaultProperties().getLatencyActive(), not(latencyActive));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #72 by introducing a `ChaosMonkeySettingsDto` which returns an `AssaultPropertiesUpdate` (which is kinda a DTO too) instead of our existing internal config object `AssaultProperties`.


<!-- Why are these changes necessary? -->

**Why**:
If somebody has Spring Cloud Dependencies and use the actuator endpoint the endpoint can have problems serializing the AssaultProperties Object.  Spring @ConfigurationProperties  beans will be proxied so that the underlying can be rebound/recreated when a configuration refresh is issued. This causes that the deserialized objects has additional properties (from the proxy, see screenshot) or cannot even be serialized like described in #72

<!-- How were these changes implemented? -->

**How**:
By not returning our ConfigurationProperties directly and abstract it in an Dto (AssaultPropertiesUpdate)

**Notes**:
On this screenshot you can see the properties which get added by the spring proxy and accidently returned
![grafik](https://user-images.githubusercontent.com/7139697/82075880-418e3900-96dd-11ea-94e9-b1e028cac2a9.png)
I dont know if we can write test for this change without huge efforts (since it relies, that on a non existing spring cloud dependency). 

I verified the behaviour with an [sample app](https://github.com/fletchgqc/mediator/tree/cmsb%2372serialization) with `2.2.0` I get above result. With `2.3.0-SNAPSHOT` (this pr locally build) I get the correct result. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
