### PR TITLE
Use chaos monkey specific scheduler to avoid multiple scheduler confl…

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -4,6 +4,7 @@
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/180[#180] Fixes serialization issues when using actuator combined with spring cloud dependencies (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/72[#72] for more details)
+- https://github.com/codecentric/chaos-monkey-spring-boot/issues/184[#184] Use chaos monkey specific scheduler to avoid multiple scheduler conflict issue when we have more than one scheduler already defined in the application code
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyScheduler.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyScheduler.java
@@ -28,11 +28,6 @@ public class ChaosMonkeyScheduler {
     this.config = config;
     this.runtimeScope = runtimeScope;
 
-    if (scheduler == null) {
-      Logger.warn(
-          "No ScheduledTaskRegistrar available in application context, scheduler is not functional");
-    }
-
     reloadConfig();
   }
 
@@ -47,14 +42,8 @@ public class ChaosMonkeyScheduler {
     }
 
     if (active) {
-      if (scheduler == null) {
-        // We might consider an exception here, since the user intent could
-        // clearly not be serviced
-        Logger.error("No scheduler available in application context, will not process schedule");
-      } else {
-        CronTask task = new CronTask(runtimeScope::callChaosMonkey, cronExpression);
-        currentTask = scheduler.scheduleCronTask(task);
-      }
+      CronTask task = new CronTask(runtimeScope::callChaosMonkey, cronExpression);
+      currentTask = scheduler.scheduleCronTask(task);
     }
   }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -144,7 +144,6 @@ public class ChaosMonkeyConfiguration {
   public ChaosMonkeyScheduler scheduler(
       @Nullable @Qualifier(CHAOS_MONKEY_TASK_SCHEDULER) TaskScheduler scheduler,
       ChaosMonkeyRuntimeScope runtimeScope) {
-    Logger.info("Creating chaos monkey scheduler with scheduler  : " + scheduler);
     ScheduledTaskRegistrar registrar = null;
     if (scheduler != null) {
       registrar = new ScheduledTaskRegistrar();

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -52,7 +52,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -142,13 +141,10 @@ public class ChaosMonkeyConfiguration {
 
   @Bean
   public ChaosMonkeyScheduler scheduler(
-      @Nullable @Qualifier(CHAOS_MONKEY_TASK_SCHEDULER) TaskScheduler scheduler,
+      @Qualifier(CHAOS_MONKEY_TASK_SCHEDULER) TaskScheduler scheduler,
       ChaosMonkeyRuntimeScope runtimeScope) {
-    ScheduledTaskRegistrar registrar = null;
-    if (scheduler != null) {
-      registrar = new ScheduledTaskRegistrar();
-      registrar.setTaskScheduler(scheduler);
-    }
+    ScheduledTaskRegistrar registrar = new ScheduledTaskRegistrar();
+    registrar.setTaskScheduler(scheduler);
     return new ChaosMonkeyScheduler(registrar, assaultProperties, runtimeScope);
   }
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -42,6 +42,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -54,6 +55,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.util.StreamUtils;
 
@@ -69,6 +71,8 @@ import org.springframework.util.StreamUtils;
 public class ChaosMonkeyConfiguration {
 
   private static final Logger Logger = LoggerFactory.getLogger(ChaosMonkeyConfiguration.class);
+
+  private static final String CHAOS_MONKEY_TASK_SCHEDULER = "chaosMonkeyTaskScheduler";
 
   private final ChaosMonkeyProperties chaosMonkeyProperties;
 
@@ -138,13 +142,20 @@ public class ChaosMonkeyConfiguration {
 
   @Bean
   public ChaosMonkeyScheduler scheduler(
-      @Nullable TaskScheduler scheduler, ChaosMonkeyRuntimeScope runtimeScope) {
+      @Nullable @Qualifier(CHAOS_MONKEY_TASK_SCHEDULER) TaskScheduler scheduler,
+      ChaosMonkeyRuntimeScope runtimeScope) {
+    Logger.info("Creating chaos monkey scheduler with scheduler  : " + scheduler);
     ScheduledTaskRegistrar registrar = null;
     if (scheduler != null) {
       registrar = new ScheduledTaskRegistrar();
       registrar.setTaskScheduler(scheduler);
     }
     return new ChaosMonkeyScheduler(registrar, assaultProperties, runtimeScope);
+  }
+
+  @Bean(name = CHAOS_MONKEY_TASK_SCHEDULER)
+  public TaskScheduler chaosMonkeyTaskScheduler() {
+    return new ThreadPoolTaskScheduler();
   }
 
   @Bean

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeySchedulerTest.java
@@ -28,13 +28,6 @@ class ChaosMonkeySchedulerTest {
   @Mock private ChaosMonkeyRuntimeScope scope;
 
   @Test
-  void shouldTolerateMissingRegistry() {
-    when(config.getRuntimeAssaultCronExpression()).thenReturn("*/5 * * * * ?");
-    new ChaosMonkeyScheduler(null, config, scope);
-    // no exception despite null injection
-  }
-
-  @Test
   void shouldRespectTheOffSetting() {
     when(config.getRuntimeAssaultCronExpression()).thenReturn("OFF");
 


### PR DESCRIPTION
Use chaos monkey specific scheduler to avoid multiple scheduler conflict issue when we have more than one scheduler already defined in the application code

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Created a new TaskScheduler named chaosMonkeyScheduler.

<!-- Why are these changes necessary? -->

**Why**: When we have more than one scheduler already defined in the application code like say "taskScheduler" created by spring boot and "catalogWatchTaskScheduler" by consul, the chaosMonkey to autowire the scheduler it fails with exception "ChaosMonkeyConfiguration required a single bean, but 2 were found:".

This also gives us facility to tune our scheduler accordingly if needed in future.

<!-- How were these changes implemented? -->

**How**: Added a new Bean named "chaosMonkeyTaskScheduler" and using it to create ChaosMonkeyScheduler in scheduler(...) method with Qualifier attribute as chaosMonkeyTaskScheduler on TaskScheduler parameter.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A
      <!-- Thank you so much for that! -->
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
