### PR TITLE
Excluding final classes from watcher aspects

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
@@ -25,7 +25,7 @@ abstract class ChaosMonkeyBaseAspect {
   @Pointcut("within(de.codecentric.spring.boot.chaos.monkey..*)")
   public void classInChaosMonkeyPackage() {}
 
-  @Pointcut("execution(* *.*(..))")
+  @Pointcut("!within(is(FinalType)) && execution(* *.*(..))")
   public void allPublicMethodPointcut() {}
 
   String calculatePointcut(String target) {


### PR DESCRIPTION
Spring AOP causes a runtime failure when trying to override a final class through pointcut. This fix will help in simply excluding the final classes from AOP scan.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixing the following issue : https://github.com/codecentric/chaos-monkey-spring-boot/issues/188
<!-- Why are these changes necessary? -->

**Why**:
Chaos monkey watcher aspect classes use spring AOP to scan for public methods,  Spring AOP can't make the required proxy in cases where is a final class present.
<!-- How were these changes implemented? -->

**How**:
I'm modifying the common pointcut viz. allPublicMethodPointcut() that is used across all chaos monkey watcher classes e.g: SpringComponentApect, SpringServiceAspect, SpringControllerAspect, etc. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ ] Changelog updated N/A
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
