### PR TITLE
Problem: Proxying final component classes results in IllegalArgumentException

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -5,6 +5,7 @@
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/180[#180] Fixes serialization issues when using actuator combined with spring cloud dependencies (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/72[#72] for more details)
 - https://github.com/codecentric/chaos-monkey-spring-boot/issues/184[#184] Use chaos monkey specific scheduler to avoid multiple scheduler conflict issue when we have more than one scheduler already defined in the application code
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/191[#191] Prevent chaos monkey from attempting to proxy final components which fails with an `IllegalArgumentException`
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
@@ -25,7 +25,7 @@ abstract class ChaosMonkeyBaseAspect {
   @Pointcut("within(de.codecentric.spring.boot.chaos.monkey..*)")
   public void classInChaosMonkeyPackage() {}
 
-  @Pointcut("execution(* *.*(..))")
+  @Pointcut("!within(is(FinalType)) && execution(* *.*(..))")
   public void allPublicMethodPointcut() {}
 
   String calculatePointcut(String target) {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.spring.boot.chaos.monkey.watcher;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyRequestScope;
+import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
+import de.codecentric.spring.boot.chaos.monkey.component.MetricType;
+import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent;
+import de.codecentric.spring.boot.demo.chaos.monkey.component.FinalDemoComponent;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+/** @author Kevin Sapper */
+@SpringBootTest
+class SpringComponentAspectIntegrationTest {
+
+  private static final String demoComponentPointcutName = "execution.DemoComponent.sayHello";
+  private static final String finalDemoComponentPointcutName =
+      "execution.FinalDemoComponent.sayHello";
+
+  private static final String demoComponentSimpleName =
+      "de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello";
+  private static final String finalDemoComponentSimpleName =
+      "de.codecentric.spring.boot.demo.chaos.monkey.component.FinalDemoComponent.sayHello";
+
+  @Autowired DemoComponent demoComponent;
+
+  @Autowired FinalDemoComponent finalDemoComponent;
+
+  @Autowired ChaosMonkeyRequestScope chaosMonkeyRequestScopeMock;
+
+  @Autowired MetricEventPublisher metricsMock;
+
+  @Test
+  public void chaosMonkeyIsCalledWhenComponentIsNotFinal() {
+    demoComponent.sayHello();
+    verify(chaosMonkeyRequestScopeMock, times(1)).callChaosMonkey(demoComponentSimpleName);
+    verify(metricsMock, times(1))
+        .publishMetricEvent(demoComponentPointcutName, MetricType.COMPONENT);
+  }
+
+  @Test
+  public void chaosMonkeyIsNotCalledWhenComponentIsFinal() {
+    finalDemoComponent.sayHello();
+    verify(chaosMonkeyRequestScopeMock, times(0)).callChaosMonkey(finalDemoComponentSimpleName);
+    verify(metricsMock, times(0))
+        .publishMetricEvent(finalDemoComponentPointcutName, MetricType.COMPONENT);
+  }
+
+  @Configuration
+  @EnableAspectJAutoProxy
+  public static class TestContext {
+
+    @Bean
+    public ChaosMonkeyRequestScope chaosMonkeyRequestScopeMock() {
+      return mock(ChaosMonkeyRequestScope.class);
+    }
+
+    @Bean
+    public MetricEventPublisher metricsMock() {
+      return mock(MetricEventPublisher.class);
+    }
+
+    @Bean
+    SpringComponentAspect aspect() {
+      WatcherProperties watcherProperties = new WatcherProperties();
+      watcherProperties.setComponent(true);
+      return new SpringComponentAspect(
+          chaosMonkeyRequestScopeMock(), metricsMock(), watcherProperties);
+    }
+
+    @Bean
+    DemoComponent demoComponent() {
+      return mock(DemoComponent.class);
+    }
+
+    @Bean
+    FinalDemoComponent finalDemoComponent() {
+      return mock(FinalDemoComponent.class);
+    }
+  }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/FinalDemoComponent.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/FinalDemoComponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.spring.boot.demo.chaos.monkey.component;
+
+import org.springframework.stereotype.Component;
+
+/** @author Kevin Sapper */
+@Component
+public final class FinalDemoComponent {
+
+  public String sayHello() {
+    return "Hello!";
+  }
+}


### PR DESCRIPTION
Solution: Exclude final component classes from being proxied

**What**:
Fixes #188

**Why**:
Choas monkey's watcher aspect will try to proxy every spring component. This attempt will fail for final classes though.

**How**:
Use an pointcut expression to exclude all final spring components

**Checklist**:

- [x] Documentation added - Not necessary
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
- [x] Ready to be merged