### PR TITLE
Add devcontainer config (for codespaces/devcontainers)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	// Template from https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java-8/.devcontainer
+	"name": "CMSB (Java)",
+	"image": "mcr.microsoft.com/vscode/devcontainers/java:8",
+	
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"java.home": "/docker-java-home",
+		"java.configuration.runtimes": [{
+			"default": true,
+			"name": "JavaSE-1.8",
+			"path": "/usr/local/sdkman/candidates/java/current"
+		}]
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vscjava.vscode-java-pack",
+		"gabrielbb.vscode-lombok",
+		"pivotal.vscode-boot-dev-pack"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -14,6 +14,7 @@
 - https://github.com/codecentric/chaos-monkey-spring-boot/issues/162[#162] Change default configuration to everything off and predictable values
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/175[#175] Because https://github.com/codecentric/chaos-monkey-spring-boot/pull/160[#160] failed horribly regarding ease of development, introduce spotless instead
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/177[#177] Harmonize test naming.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/194[#194] Introduce dev containers (for https://github.com/features/codespaces[Github Codespaces] and https://code.visualstudio.com/docs/remote/containers[VS Code])
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
I added a basic configuration to enable [devcontainers](https://github.com/microsoft/vscode-dev-containers) in chaos monkey.
This is a result of my tinkering with the github [Codespaces](https://github.com/features/codespaces) beta.

CSMB in Codespace (vscode in a browser) running `./mnvw install` 🎉 

![codespacesmnvwinstall](https://user-images.githubusercontent.com/7139697/104042248-84f06700-51da-11eb-8f2b-5f15a7f05291.png)


<!-- Why are these changes necessary? -->

**Why**:
They are not really necessary. 

It could help (first time) contributors, to make the initial project setup easier. They can open the devcontainer either using Codespaces or VS Code and then theyre set. 

![codespace](https://user-images.githubusercontent.com/7139697/104043006-78204300-51db-11eb-858c-7c7a96aa1cd2.png)
![vscodedevcontainer](https://user-images.githubusercontent.com/7139697/104043089-98e89880-51db-11eb-8ab3-9be46b18760d.png)


<!-- How were these changes implemented? -->

**How**:
By supplying a devcontainer.json with all needed settings (extensions, such as lombok...)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I leave this open for inputs/comments. I would like to hear your thoughts :) 