### PR TITLE
fix vulnerability CVE-2020-25649 because of jackson-databind dependency

### DIFF
--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-            <version>${spring-boot.version}</version>
+            <version>2.2.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -128,7 +128,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-            <version>2.2.6.RELEASE</version>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.3</version>
+            <scope>compile</scope>
         </dependency>
 
 


### PR DESCRIPTION
**What**:
We are using the jar with dependencies in a side car container during deployment of our spring boot application.
Every image we build is scaned for security vulnerabilities.
The transitive dependency jackson-databind 2.10.3 is provided via spring-boot-actuator-autoconfigure version 2.2.6-RELEASE. This version leads to the security vulnerability CVE-2020-25649 during our automatic scans.

**Why**:
- Fixes the security vulnerability CVE-2020-25649

**How**:
- Add an explicit jackson-databind version 2.11.3 dependency

**Checklist**:
- [ ] Documentation added
- [ ] Changelog updated
- [ ] Tests added
- [X] Ready to be merged