### PR TITLE
Problem: Proxying components that use BeanPostProcessor or ApplicationListener interfaces prevents Spring Boot application from starting up

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -6,6 +6,7 @@
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/180[#180] Fixes serialization issues when using actuator combined with spring cloud dependencies (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/72[#72] for more details)
 - https://github.com/codecentric/chaos-monkey-spring-boot/issues/184[#184] Use chaos monkey specific scheduler to avoid multiple scheduler conflict issue when we have more than one scheduler already defined in the application code
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/191[#191] Prevent chaos monkey from attempting to proxy final components which fails with an `IllegalArgumentException`
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/200[#200] Prevent chaos monkey from proxying BeanPostProcessor and ApplicationListener methods (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/199[#199] for more details)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,21 +3,10 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/180[#180] Fixes serialization issues when using actuator combined with spring cloud dependencies (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/72[#72] for more details)
-- https://github.com/codecentric/chaos-monkey-spring-boot/issues/184[#184] Use chaos monkey specific scheduler to avoid multiple scheduler conflict issue when we have more than one scheduler already defined in the application code
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/191[#191] Prevent chaos monkey from attempting to proxy final components which fails with an `IllegalArgumentException`
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/200[#200] Prevent chaos monkey from proxying BeanPostProcessor and ApplicationListener methods (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/199[#199] for more details)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/163[#163] Fix wrong docs about configuration of watcher at runtime
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/160[#160] Introduce Google Style Guide
-- https://github.com/codecentric/chaos-monkey-spring-boot/issues/162[#162] Change default configuration to everything off and predictable values
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/175[#175] Because https://github.com/codecentric/chaos-monkey-spring-boot/pull/160[#160] failed horribly regarding ease of development, introduce spotless instead
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/177[#177] Harmonize test naming.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/194[#194] Introduce dev containers (for https://github.com/features/codespaces[Github Codespaces] and https://code.visualstudio.com/docs/remote/containers[VS Code])
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/192[#192] Upgrade dependencies (Spring Boot 2.3.6 and many more...) and removed JUnit 4
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/195[#195] Switch from Travis to Github Actions + Switch to default branch "main"
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -26,9 +15,6 @@
 This release was only possible because of these great humans:
 
 // - https://github.com/octocat[@octocat]
-- https://github.com/maiksensi[@maiksensi]
-- https://github.com/WtfJoke[@WtfJoke]
-- https://github.com/fletchgqc[@fletchgqc]
-- https://github.com/Glosur[@glosur]
+- https://github.com/alexfincham[@alexfincham]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
@@ -28,6 +28,9 @@ abstract class ChaosMonkeyBaseAspect {
   @Pointcut("!within(is(FinalType)) && execution(* *.*(..))")
   public void allPublicMethodPointcut() {}
 
+  @Pointcut("execution(* postProcess*Initialization(..)) || execution(* onApplicationEvent(..))")
+  public void springHooksPointcut() {}
+
   String calculatePointcut(String target) {
     return target.replaceAll("\\(\\)", "").replaceAll("\\)", "").replaceAll("\\(", ".");
   }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspect.java
@@ -48,7 +48,7 @@ public class SpringComponentAspect extends ChaosMonkeyBaseAspect {
 
   @Around(
       "classAnnotatedWithComponentPointcut() && !classInSpringCloudContextPackage() "
-          + "&& allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
+          + "&& allPublicMethodPointcut() && !classInChaosMonkeyPackage() && !springHooksPointcut()")
   public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
     if (watcherProperties.isComponent()) {
       log.debug("Watching public method on component class: {}", pjp.getSignature());

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringServiceAspect.java
@@ -41,10 +41,11 @@ public class SpringServiceAspect extends ChaosMonkeyBaseAspect {
   private WatcherProperties watcherProperties;
 
   @Pointcut("within(@org.springframework.stereotype.Service *)")
-  public void classAnnotatedWithControllerPointcut() {}
+  public void classAnnotatedWithServicePointcut() {}
 
   @Around(
-      "classAnnotatedWithControllerPointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()")
+      "classAnnotatedWithServicePointcut() && allPublicMethodPointcut() && !classInChaosMonkeyPackage()"
+          + "&& !springHooksPointcut()")
   public Object intercept(ProceedingJoinPoint pjp) throws Throwable {
 
     if (watcherProperties.isService()) {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
@@ -24,11 +24,15 @@ import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyRequestScope
 import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
 import de.codecentric.spring.boot.chaos.monkey.component.MetricType;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import de.codecentric.spring.boot.demo.chaos.monkey.component.ApplicationListenerComponent;
+import de.codecentric.spring.boot.demo.chaos.monkey.component.BeanPostProcessorComponent;
 import de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent;
 import de.codecentric.spring.boot.demo.chaos.monkey.component.FinalDemoComponent;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -40,15 +44,27 @@ class SpringComponentAspectIntegrationTest {
   private static final String demoComponentPointcutName = "execution.DemoComponent.sayHello";
   private static final String finalDemoComponentPointcutName =
       "execution.FinalDemoComponent.sayHello";
+  private static final String beanPostProcessorComponentPointcutName =
+      "execution.BeanPostProcessorComponent.postProcessBeforeInitialization";
+  private static final String applicationListenerComponentPointcutName =
+      "execution.ApplicationListenerComponent.onApplicationEvent";
 
   private static final String demoComponentSimpleName =
       "de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello";
   private static final String finalDemoComponentSimpleName =
       "de.codecentric.spring.boot.demo.chaos.monkey.component.FinalDemoComponent.sayHello";
+  private static final String beanPostProcessorComponentSimpleName =
+      "de.codecentric.spring.boot.demo.chaos.monkey.component.BeanPostProcessorComponent.postProcessBeforeInitialization";
+  private static final String applicationListenerComponentSimpleName =
+      "de.codecentric.spring.boot.demo.chaos.monkey.component.ApplicationListenerComponent.onApplicationEvent";
 
   @Autowired DemoComponent demoComponent;
 
   @Autowired FinalDemoComponent finalDemoComponent;
+
+  @Autowired BeanPostProcessorComponent beanPostProcessorComponent;
+
+  @Autowired ApplicationListenerComponent applicationListenerComponent;
 
   @Autowired ChaosMonkeyRequestScope chaosMonkeyRequestScopeMock;
 
@@ -70,8 +86,24 @@ class SpringComponentAspectIntegrationTest {
         .publishMetricEvent(finalDemoComponentPointcutName, MetricType.COMPONENT);
   }
 
+  @Test
+  public void chaosMonkeyDoesNotProxyIgnoredSpringInterfaces() {
+    beanPostProcessorComponent.postProcessBeforeInitialization(new Object(), "fakeBean");
+    applicationListenerComponent.onApplicationEvent(mock(ApplicationEvent.class));
+
+    verify(chaosMonkeyRequestScopeMock, times(0))
+        .callChaosMonkey(beanPostProcessorComponentSimpleName);
+    verify(metricsMock, times(0))
+        .publishMetricEvent(beanPostProcessorComponentPointcutName, MetricType.COMPONENT);
+
+    verify(chaosMonkeyRequestScopeMock, times(0))
+        .callChaosMonkey(applicationListenerComponentSimpleName);
+    verify(metricsMock, times(0))
+        .publishMetricEvent(applicationListenerComponentPointcutName, MetricType.COMPONENT);
+  }
+
   @Configuration
-  @EnableAspectJAutoProxy
+  @EnableAspectJAutoProxy(proxyTargetClass = true)
   public static class TestContext {
 
     @Bean
@@ -100,6 +132,16 @@ class SpringComponentAspectIntegrationTest {
     @Bean
     FinalDemoComponent finalDemoComponent() {
       return mock(FinalDemoComponent.class);
+    }
+
+    @Bean
+    BeanPostProcessorComponent beanPostProcessorComponent() {
+      return mock(BeanPostProcessorComponent.class);
+    }
+
+    @Bean
+    ApplicationListenerComponent applicationListenerComponent() {
+      return mock(ApplicationListenerComponent.class);
     }
   }
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/SpringComponentAspectIntegrationTest.java
@@ -31,7 +31,6 @@ import de.codecentric.spring.boot.demo.chaos.monkey.component.FinalDemoComponent
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/ApplicationListenerComponent.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/ApplicationListenerComponent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.spring.boot.demo.chaos.monkey.component;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+/** @author Alex Fincham */
+@Component
+public class ApplicationListenerComponent implements ApplicationListener<ApplicationEvent> {
+  @Override
+  public void onApplicationEvent(ApplicationEvent applicationEvent) {
+    // this can be empty
+  }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/BeanPostProcessorComponent.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/component/BeanPostProcessorComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.spring.boot.demo.chaos.monkey.component;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+/** @author Alex Fincham */
+@Component
+public class BeanPostProcessorComponent implements BeanPostProcessor {
+
+  public String sayHello() {
+    return "Hello!";
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName)
+      throws BeansException {
+    return bean;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    return bean;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8
     </project.reporting.outputEncoding>
-    <revision>2.3.0-SNAPSHOT</revision>
+    <revision>2.3.1-SNAPSHOT</revision>
     <site-maven-plugin.version>0.12</site-maven-plugin.version>
     <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
     <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
@@ -71,7 +71,7 @@
       scm:git:git://github.com/codecentric/chaos-monkey-spring-boot.git
     </connection>
     <developerConnection>
-      scm:git:ssh://git@github.com:codecentric/chaos-monkey-spring-boot.git
+      scm:git:ssh://git@github.com/codecentric/chaos-monkey-spring-boot.git
     </developerConnection>
     <url>https://github.com/codecentric/chaos-monkey-spring-boot</url>
   </scm>


### PR DESCRIPTION
Solution: Exclude BeanPostProcessor and ApplicationListener method implementations from being proxied

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #199
<!-- Why are these changes necessary? -->

**Why**:
When Chaos monkey tries to proxy spring components that implement **`org.springframework.beans.factory.config.BeanPostProcessor`** a `BeanCurrentlyInCreationException` is thrown during start up because the first time that `postProcess[Before|After]Initialization` is called, all Chaos monkey beans have not bean fully initialized yet.  Also, when Chaos monkey tries to proxy spring components that implement **`org.springframework.context.ApplicationListener`** a `StackOverflowError` occurs due to an infinite loop that results when a call to `onApplicationEvent` is intercepted by a watcher aspect, which publishes an event itself using `MetricEventPublisher`
<!-- How were these changes implemented? -->

**How**:
Use a pointcut expression to exclude BeanPostProcessor and ApplicationListener method execution join points
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added - N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
