### PR TITLE
Remove reference to old spring-boot-actuator-autoconfigure

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,6 +3,7 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/202[#202] Remove reference to old spring-boot-actuator-autoconfigure
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -13,6 +14,6 @@
 === Contributors
 This release was only possible because of these great humans:
 
-// - https://github.com/octocat[@octocat]
+- https://github.com/WtfJoke[@WtfJoke]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -125,17 +125,6 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-            <version>2.2.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.11.3</version>
-            <scope>compile</scope>
-        </dependency>
 
 
     </dependencies>

--- a/demo-apps/chaos-monkey-demo-app/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.0.4</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Use bundled micrometer version in demo project

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The same as in #198 but this time the less intrusive way. 
<!-- Why are these changes necessary? -->
In #198 jackson-databind was changed to a newer resolution. However the root cause was the mistakenly (old version) added spring-boot-autoconfigure during #192 

I removed the dependency again and needed to upgrade the micrometer version of the demo project to the micrometer version bundled with spring boot
**Why**:
To avoid having old dependencies in subproject
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
