### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,8 +38,8 @@ jobs:
 
   deploy:
     needs: build
-    name: "Publish artifacts"
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    name: "Publish snapshot artifacts"
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version (2.X.X) to be released"
+        required: true
+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+
+    steps:
+      - name: Install semver
+        run: sudo apt-get install -y node-semver
+      - name: Validate is valid version
+        run: semver $VERSION
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN_CHAOS_BOT }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Configure Git
+        run: |
+          git config user.email "54942692+ChaosMonkeyBot@users.noreply.github.com"
+          git config user.name "Chaos Monkey Bot"
+      - name: Bump Version
+        run: ./mvnw versions:set-property -Dproperty=revision -DnewVersion=$VERSION
+      - name: Tag
+        run: |
+          git commit -m "Release $VERSION" -o pom.xml
+          git tag -a -m "Release $VERSION" v$VERSION
+      - name: Move to next Snapshot
+        run: |
+          NEXT_VERSION=`semver $VERSION -i`-SNAPSHOT
+          ./mvnw versions:set-property -Dproperty=revision -DnewVersion=$NEXT_VERSION
+          git commit -m "Prepare for next version: $NEXT_VERSION" -o pom.xml
+      - name: Push (Release Tag + Main Branch)
+        run: git push --follow-tags

--- a/.github/workflows/releasetag.yml
+++ b/.github/workflows/releasetag.yml
@@ -1,0 +1,39 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - v*
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run Maven deploy
+        run: ./mvnw deploy -DperformRelease=true --settings .settings.xml
+        env:
+          SONATYPE_USERTOKEN: ${{ secrets.SONATYPE_USERTOKEN }}
+          SONATYPE_USERTOKENPASSWORD: ${{ secrets.SONATYPE_USERTOKENPASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./chaos-monkey-docs/target/generated-docs
+          destination_dir: latest
+          commit_message: ${{ github.event.head_commit.message }}

--- a/.settings.xml
+++ b/.settings.xml
@@ -8,5 +8,9 @@
 	  <username>${env.SONATYPE_USERTOKEN}</username>
       <password>${env.SONATYPE_USERTOKENPASSWORD}</password>
     </server>
+    <server>
+      <id>gpg.passphrase</id>
+      <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+    </server>
   </servers>
 </settings>

--- a/chaos-monkey-docs/pom.xml
+++ b/chaos-monkey-docs/pom.xml
@@ -68,44 +68,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.github</groupId>
-                        <artifactId>site-maven-plugin</artifactId>
-                        <version>${site-maven-plugin.version}</version>
-                        <configuration>
-                            <message>Creating Reference Guide for ${project.version}</message>
-                            <path>${project.version}</path>
-                            <merge>true</merge>
-                            <dryRun>false</dryRun>
-                            <outputDirectory>target/generated-docs</outputDirectory>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>site</goal>
-                                </goals>
-                                <phase>site</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-project-info-reports-plugin</artifactId>
-                        <version>${maven-project-info-reports-plugin.version}</version>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,10 +3,10 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/202[#202] Remove reference to old spring-boot-actuator-autoconfigure
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/204[#204] [CI] Added release workflow
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
@@ -264,6 +263,13 @@
                 </goals>
                 <id>sign-artifacts</id>
                 <phase>verify</phase>
+                <!-- To avoid maven gpg: signing failed: Inappropriate ioctl for device in CI -->
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Add workflow (release.yml) for drafting a new release
- Add workflow (releasetag.yml) for publishing the artifacts of a tagged release
- Publish docs to gh-pages branch
- Sign artifacts using gpg key of chaos monkey bot
- Remove no more needed github maven site plugin and its configuration

<!-- Why are these changes necessary? -->

**Why**:
Releasing Chaos Monkey is a pain, this should soften this pain a bit
<!-- How were these changes implemented? -->

**How**:
By adding a workflow to draft a release. It uses a newly generated GPG Key (of @ChaosMonkeyBot ) to sign the artifacts so that the release will be published to maven central. It uses also a Personal Access Github Token to push the version bump to the protected branch main.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
