### PR TITLE
Problem: Environment properties can clash with chaos monkey properties and prevent app start up

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,10 +3,12 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/200[#200] Prevent chaos monkey from proxying BeanPostProcessor and ApplicationListener methods (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/199[#199] for more details)
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/210[#210] Eliminate potential name clash between config props and ENV variables (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/209[#209] for more details)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/204[#204] [CI] Added release workflow
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -15,5 +17,7 @@
 This release was only possible because of these great humans:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/alexfincham[@alexfincham]
+- https://github.com/WtfJoke[@WtfJoke]
 
 Thank you for your support!

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,11 +3,10 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/200[#200] Prevent chaos monkey from proxying BeanPostProcessor and ApplicationListener methods (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/199[#199] for more details)
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/210[#210] Eliminate potential name clash between config props and ENV variables (see https://github.com/codecentric/chaos-monkey-spring-boot/issues/209[#209] for more details)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/204[#204] [CI] Added release workflow
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -16,7 +15,5 @@
 This release was only possible because of these great humans:
 
 // - https://github.com/octocat[@octocat]
-- https://github.com/alexfincham[@alexfincham]
-- https://github.com/WtfJoke[@WtfJoke]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -26,7 +26,6 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -38,62 +37,49 @@ import org.springframework.validation.annotation.Validated;
 @NoArgsConstructor
 @ConfigurationProperties(prefix = "chaos.monkey.assaults")
 @Validated
-@EqualsAndHashCode
 @AssaultPropertiesLatencyRangeConstraint
 public class AssaultProperties {
-  @Value("${level : 1}")
   @Min(value = 1)
   @Max(value = 10000)
-  private int level;
+  private int level = 1;
 
-  @Value("${latencyRangeStart : 1000}")
   @Min(value = 1)
   @Max(value = Integer.MAX_VALUE)
-  private int latencyRangeStart;
+  private int latencyRangeStart = 1000;
 
-  @Value("${latencyRangeEnd : 3000}")
   @Min(value = 1)
   @Max(value = Integer.MAX_VALUE)
-  private int latencyRangeEnd;
+  private int latencyRangeEnd = 3000;
 
-  @Value("${latencyActive : false}")
-  private boolean latencyActive;
+  private boolean latencyActive = false;
 
-  @Value("${exceptionsActive : false}")
-  private boolean exceptionsActive;
+  private boolean exceptionsActive = false;
 
   @AssaultExceptionConstraint private AssaultException exception;
 
-  @Value("${killApplicationActive : false}")
-  private boolean killApplicationActive;
+  private boolean killApplicationActive = false;
 
-  @Value("${memoryActive : false}")
-  private volatile boolean memoryActive;
+  private volatile boolean memoryActive = false;
 
-  @Value("${memoryMillisecondsHoldFilledMemory : 90000}")
   @Min(value = 1500)
   @Max(value = Integer.MAX_VALUE)
-  private int memoryMillisecondsHoldFilledMemory;
+  private int memoryMillisecondsHoldFilledMemory = 90000;
 
-  @Value("${memoryMillisecondsWaitNextIncrease : 1000}")
   @Min(value = 100)
   @Max(value = 30000)
-  private int memoryMillisecondsWaitNextIncrease;
+  private int memoryMillisecondsWaitNextIncrease = 1000;
 
-  @Value("${memoryFillIncrementFraction : 0.15}")
   @DecimalMax("1.0")
   @DecimalMin("0.01")
-  private double memoryFillIncrementFraction;
+  private double memoryFillIncrementFraction = 0.15;
 
-  @Value("${memoryFillTargetFraction : 0.25}")
   @DecimalMax("1.0")
   @DecimalMin("0.01")
-  private double memoryFillTargetFraction;
+  private double memoryFillTargetFraction = 0.25;
 
-  @Value("${runtime.scope.assault.cron.expression:OFF}")
+  @Value("${chaos.monkey.assaults.runtime.scope.assault.cron.expression:OFF}")
   private String runtimeAssaultCronExpression;
 
-  @Value("${watchedCustomServices:#{null}}")
   private List<String> watchedCustomServices;
 
   public AssaultException getException() {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyProperties.java
@@ -17,7 +17,6 @@
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -25,7 +24,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @NoArgsConstructor
 @ConfigurationProperties(prefix = "chaos.monkey")
-@EqualsAndHashCode
 public class ChaosMonkeyProperties {
 
   @Value("${enabled:false}")

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyProperties.java
@@ -18,7 +18,6 @@ package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
@@ -26,6 +25,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "chaos.monkey")
 public class ChaosMonkeyProperties {
 
-  @Value("${enabled:false}")
-  private boolean enabled;
+  private boolean enabled = false;
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeySettings.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeySettings.java
@@ -20,14 +20,12 @@ import de.codecentric.spring.boot.chaos.monkey.endpoints.ChaosMonkeySettingsDto;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /** @author Benjamin Wilms */
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@EqualsAndHashCode
 public class ChaosMonkeySettings {
 
   @NotNull private ChaosMonkeyProperties chaosMonkeyProperties;

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/WatcherProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/WatcherProperties.java
@@ -17,30 +17,22 @@
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** @author Benjamin Wilms */
 @Data
 @NoArgsConstructor
 @ConfigurationProperties(prefix = "chaos.monkey.watcher")
-@EqualsAndHashCode
 public class WatcherProperties {
 
-  @Value("${controller:false}")
-  private boolean controller;
+  private boolean controller = false;
 
-  @Value("${restController:false}")
-  private boolean restController;
+  private boolean restController = false;
 
-  @Value("${service:false}")
-  private boolean service;
+  private boolean service = false;
 
-  @Value("${repository:false}")
-  private boolean repository;
+  private boolean repository = false;
 
-  @Value("${component:false}")
-  private boolean component;
+  private boolean component = false;
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/AssaultPropertiesUpdate.java
@@ -80,9 +80,9 @@ public class AssaultPropertiesUpdate {
   }
 
   public void applyTo(AssaultProperties t) {
-    this.applyTo(level, t::setLevel);
-    this.applyTo(latencyActive, t::setLatencyActive);
-    this.applyTo(latencyRangeStart, t::setLatencyRangeStart);
+    applyTo(level, t::setLevel);
+    applyTo(latencyActive, t::setLatencyActive);
+    applyTo(latencyRangeStart, t::setLatencyRangeStart);
     applyTo(latencyRangeEnd, t::setLatencyRangeEnd);
 
     applyTo(exceptionsActive, t::setExceptionsActive);


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #209 

<!-- Why are these changes necessary? -->

**Why**:
Currently when a client app is run with Environment variables that have the same name as any chaos monkey properties, the ENV variables take precedence and clash with the chaos monkey properties due to the SpEL expressions used with **`@Value`** annotation.  This can prevent the client app from starting up.

<!-- How were these changes implemented? -->

**How**:
**`@ConfigurationProperties`** uses setter injection for config properties by default so the use of field injection through the **`@Value`** annotation within classes already annotated by **`@ConfigurationProperties`** is redundant and also error prone.  The problem was solved through removing all of these redundant uses of **`@Value`** and using the full property path for the one case where property path does not directly map to property setter (field **`runtimeAssaultCronExpression`** within **`AssaultProperties`** class).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
