### PR TITLE
Fix: Assaults can be activated by actuator again

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -3,6 +3,7 @@
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/219[#219] Assaults could not be activated by actuator
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyBaseAspect.java
@@ -28,7 +28,8 @@ abstract class ChaosMonkeyBaseAspect {
   @Pointcut("!within(is(FinalType)) && execution(* *.*(..))")
   public void allPublicMethodPointcut() {}
 
-  @Pointcut("execution(* postProcess*Initialization(..)) || execution(* onApplicationEvent(..))")
+  @Pointcut(
+      "execution(* postProcess*Initialization(..)) || (execution(* onApplicationEvent(..)) && !execution(* onApplicationEvent(org.springframework.web.context.support.RequestHandledEvent)))")
   public void springHooksPointcut() {}
 
   String calculatePointcut(String target) {

--- a/demo-apps/chaos-monkey-demo-app/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/demo-apps/chaos-monkey-demo-app/src/test/resources/application-test.properties
+++ b/demo-apps/chaos-monkey-demo-app/src/test/resources/application-test.properties
@@ -16,3 +16,6 @@
 spring.profiles.active=chaos-monkey
 chaos.monkey.assaults.latency-range-start=10
 chaos.monkey.assaults.latency-range-end=50
+
+# set management port to 0 to use default port
+management.server.port=0


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
A side effect of the fix of #200 introduced that assaults which have been enabled by actuator didnt work anymore. 
Fixes #217 and close #199 (which was reopened)
<!-- Why are these changes necessary? -->

**Why**:
To make assaults activated by actuator work again
<!-- How were these changes implemented? -->

**How**:
By excluding the RequestHandledEvent which seems to be responsible for setting the updated assault settings
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
