### PR TITLE
Fix sometimes wrong spring.factories in external jar (#218)

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -4,6 +4,7 @@
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/219[#219] Assaults could not be activated by actuator
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/222[#222] Fix sometimes wrong spring.factories in external jar (see #218)
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -140,6 +140,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/demo-apps/chaos-monkey-demo-app-ext-jar/runChaos.sh
+++ b/demo-apps/chaos-monkey-demo-app-ext-jar/runChaos.sh
@@ -1,1 +1,1 @@
-java -cp ./target/chaos-monkey-demo-app-ext-jar-2.0.3-SNAPSHOT.jar -Dloader.path=../../chaos-monkey-spring-boot/target/chaos-monkey-spring-boot-2.0.3-SNAPSHOT-jar-with-dependencies.jar org.springframework.boot.loader.PropertiesLauncher --spring.profiles.active=chaos-monkey
+java -cp ./target/chaos-monkey-demo-app-ext-jar-2.3.10-SNAPSHOT.jar -Dloader.path=../../chaos-monkey-spring-boot/target/chaos-monkey-spring-boot-2.3.10-SNAPSHOT-jar-with-dependencies.jar org.springframework.boot.loader.PropertiesLauncher --spring.profiles.active=chaos-monkey

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-assembly-plugin.version>2.1</maven-assembly-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <flatten-maven-plugin.version>1.2.2</flatten-maven-plugin.version>
     <spotless.plugin.version>2.6.1</spotless.plugin.version>


### PR DESCRIPTION
No fix found for newer maven assembly plugin versions (it seems that you might need to write a own file descriptor which excludes the file and then includes the one in our resource folder)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The custom spring.factories file (located in META-INF) in was not picked up every time instead the default spring.factories was included in the chaos-monkey-spring-boot-2.3.9-jar-with-dependencies.jar see #218.

It seems to be related to the maven assembly plugin.  Its random which spring.factories file wins the race (as the maven assembly plugin skips if a file is already present since version 2.2+). It works when downgrading the plugin to v2.1. 
<!-- Why are these changes necessary? -->

**Why**:
Solves #218
<!-- How were these changes implemented? -->

**How**:
By downgrading (and specifying a version) of the maven assembly plugin
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
