### PR TITLE
👷 Create Github Release after deployment to maven central

### DIFF
--- a/.github/workflows/releasetag.yml
+++ b/.github/workflows/releasetag.yml
@@ -39,3 +39,30 @@ jobs:
           publish_dir: ./chaos-monkey-docs/target/generated-docs
           destination_dir: latest
           commit_message: ${{ github.event.head_commit.message }}
+
+  create_github_release:
+    name: "Create Github Release"
+    needs: deploy
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.ref }}
+    steps:
+      - name: Set TAG_NAME without ref
+        run: echo "TAG_NAME_WITHOUT_REF=${TAG_NAME//refs\/tags\/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Convert changelog to docbook
+        uses: docker://asciidoctor/docker-asciidoctor:1.7
+        with:
+          args: "asciidoctor -b docbook chaos-monkey-docs/src/main/asciidoc/changes.adoc"
+      - name: Convert changelog from docbook to markdown
+        uses: docker://pandoc/core:2.14
+        with:
+          args: "-f docbook -t gfm -o changes.md chaos-monkey-docs/src/main/asciidoc/changes.xml --wrap=none"
+      - name: Replace {project-version} with release version
+        run: sed -i "s/{project-version}/$TAG_NAME_WITHOUT_REF/g" changes.md
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: changes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
With this PR we create a github release (so that we dont need to create it manually) on a new CSMB release. 
The changelog get converted automatically from ascidoc to markdown.
<!-- Why are these changes necessary? -->

**Why**:
Its bothersome to create a github release manually after it was published to maven central
<!-- How were these changes implemented? -->

**How**:
By using asciidoctor/pandoc we convert the changelog and
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [N/A] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
