### PR TITLE
Enable/Disable Endpoint timestamps

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -9,17 +9,17 @@ Built with Spring Boot {spring-boot-version}
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Improvements
+ - https://github.com/codecentric/chaos-monkey-spring-boot/pull/254[#254] Added timestamps to chaos monkey enable/disable endpoint.
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === New Features
- - https://github.com/codecentric/chaos-monkey-spring-boot/pull/254[#254] Added timestamps to chaos monkey enable/disable endpoint.
  - https://github.com/codecentric/chaos-monkey-spring-boot/pull/241[#239] Added CPU Assault
  - https://github.com/codecentric/chaos-monkey-spring-boot/pull/196[#196] Added bootstrapping method through the system property(`LOAD_CHAOS_MONKEY`).
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Contributors
 This release was only possible because of these great humans:
-
+ - https://github.com/MatthewBerk[@MatthewBerk]
 // - https://github.com/octocat[@octocat]
 
 Thank you for your support!

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -12,6 +12,7 @@ Built with Spring Boot {spring-boot-version}
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === New Features
+ - https://github.com/codecentric/chaos-monkey-spring-boot/pull/254[#254] Added timestamps to chaos monkey enable/disable endpoint.
  - https://github.com/codecentric/chaos-monkey-spring-boot/pull/241[#239] Added CPU Assault
  - https://github.com/codecentric/chaos-monkey-spring-boot/pull/196[#196] Added bootstrapping method through the system property(`LOAD_CHAOS_MONKEY`).
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
@@ -19,7 +19,8 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
-import java.time.Clock;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyDisabledDto;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyEnabledDto;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.jmx.annotation.JmxEndpoint;
@@ -77,17 +78,15 @@ public class ChaosMonkeyJmxEndpoint {
   }
 
   @WriteOperation
-  public String enableChaosMonkey() {
+  public ChaosMonkeyEnabledDto enableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return "Chaos Monkey is enabled\nActivatedAt:"
-        + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone());
+    return new ChaosMonkeyEnabledDto();
   }
 
   @WriteOperation
-  public String disableChaosMonkey() {
+  public ChaosMonkeyDisabledDto disableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return "Chaos Monkey is disabled\nDeactivatedAt:"
-        + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone());
+    return new ChaosMonkeyDisabledDto();
   }
 
   @ReadOperation

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
@@ -19,6 +19,7 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
+import java.time.Clock;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.jmx.annotation.JmxEndpoint;
@@ -78,13 +79,15 @@ public class ChaosMonkeyJmxEndpoint {
   @WriteOperation
   public String enableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return "Chaos Monkey is enabled";
+    return "Chaos Monkey is enabled\nActivatedAt:"
+        + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone());
   }
 
   @WriteOperation
   public String disableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return "Chaos Monkey is disabled";
+    return "Chaos Monkey is disabled\nDeactivatedAt:"
+        + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone());
   }
 
   @ReadOperation

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -23,6 +23,7 @@ import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeySettingsDto;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.WatcherPropertiesUpdate;
+import java.time.Clock;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -71,13 +72,19 @@ public class ChaosMonkeyRestEndpoint {
   @PostMapping("/enable")
   public ResponseEntity<String> enableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return ResponseEntity.ok().body("Chaos Monkey is enabled");
+    return ResponseEntity.ok()
+        .body(
+            "Chaos Monkey is enabled\nActivatedAt:"
+                + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone()));
   }
 
   @PostMapping("/disable")
   public ResponseEntity<String> disableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return ResponseEntity.ok().body("Chaos Monkey is disabled");
+    return ResponseEntity.ok()
+        .body(
+            "Chaos Monkey is disabled\nDeactivatedAt:"
+                + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone()));
   }
 
   @GetMapping

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -21,9 +21,10 @@ import de.codecentric.spring.boot.chaos.monkey.component.ChaosMonkeyScheduler;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyDisabledDto;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyEnabledDto;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeySettingsDto;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.WatcherPropertiesUpdate;
-import java.time.Clock;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -70,21 +71,15 @@ public class ChaosMonkeyRestEndpoint {
   }
 
   @PostMapping("/enable")
-  public ResponseEntity<String> enableChaosMonkey() {
+  public ResponseEntity<ChaosMonkeyEnabledDto> enableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return ResponseEntity.ok()
-        .body(
-            "Chaos Monkey is enabled\nActivatedAt:"
-                + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone()));
+    return ResponseEntity.ok().body(new ChaosMonkeyEnabledDto());
   }
 
   @PostMapping("/disable")
-  public ResponseEntity<String> disableChaosMonkey() {
+  public ResponseEntity<ChaosMonkeyDisabledDto> disableChaosMonkey() {
     this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return ResponseEntity.ok()
-        .body(
-            "Chaos Monkey is disabled\nDeactivatedAt:"
-                + Clock.systemDefaultZone().instant().atZone(Clock.systemDefaultZone().getZone()));
+    return ResponseEntity.ok().body(new ChaosMonkeyDisabledDto());
   }
 
   @GetMapping

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyDisabledDto.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyDisabledDto.java
@@ -1,0 +1,10 @@
+package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
+
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+public class ChaosMonkeyDisabledDto {
+  private final String status = "Chaos Monkey is disabled";
+  private ZonedDateTime disabledAt = ZonedDateTime.now();
+}

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyEnabledDto.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyEnabledDto.java
@@ -1,0 +1,10 @@
+package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
+
+import java.time.ZonedDateTime;
+import lombok.Data;
+
+@Data
+public class ChaosMonkeyEnabledDto {
+  private final String status = "Chaos Monkey is enabled";
+  private ZonedDateTime enabledAt = ZonedDateTime.now();
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -16,15 +16,17 @@
 
 package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyDisabledDto;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyEnabledDto;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,16 +108,18 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
   @Test
   void enableChaosMonkey() {
     ZonedDateTime enabledAt = ZonedDateTime.now();
-    ZonedDateTime timeReturned = chaosMonkeyJmxEndpoint.enableChaosMonkey().getEnabledAt();
-    assertTrue(timeReturned.isAfter(enabledAt) || timeReturned.isEqual(enabledAt));
+    ChaosMonkeyEnabledDto enabledDto = chaosMonkeyJmxEndpoint.enableChaosMonkey();
+    assertThat(enabledDto.getStatus()).isEqualTo("Chaos Monkey is enabled");
+    assertThat(enabledDto.getEnabledAt()).isAfterOrEqualTo(enabledAt);
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(true));
   }
 
   @Test
   void disableChaosMonkey() {
     ZonedDateTime disabledAt = ZonedDateTime.now();
-    ZonedDateTime timeReturned = chaosMonkeyJmxEndpoint.disableChaosMonkey().getDisabledAt();
-    assertTrue(timeReturned.isAfter(disabledAt) || timeReturned.isEqual(disabledAt));
+    ChaosMonkeyDisabledDto disabledDto = chaosMonkeyJmxEndpoint.disableChaosMonkey();
+    assertThat(disabledDto.getStatus()).isEqualTo("Chaos Monkey is disabled");
+    assertThat(disabledDto.getDisabledAt()).isAfterOrEqualTo(disabledAt);
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(false));
   }
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -19,6 +19,7 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperties;
@@ -103,13 +104,13 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
 
   @Test
   void enableChaosMonkey() {
-    assertThat(chaosMonkeyJmxEndpoint.enableChaosMonkey(), is("Chaos Monkey is enabled"));
+    assertThat(chaosMonkeyJmxEndpoint.enableChaosMonkey(), startsWith("Chaos Monkey is enabled"));
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(true));
   }
 
   @Test
   void disableChaosMonkey() {
-    assertThat(chaosMonkeyJmxEndpoint.disableChaosMonkey(), is("Chaos Monkey is disabled"));
+    assertThat(chaosMonkeyJmxEndpoint.disableChaosMonkey(), startsWith("Chaos Monkey is disabled"));
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(false));
   }
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -19,12 +19,13 @@ package de.codecentric.spring.boot.chaos.monkey.endpoints;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -104,13 +105,17 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
 
   @Test
   void enableChaosMonkey() {
-    assertThat(chaosMonkeyJmxEndpoint.enableChaosMonkey(), startsWith("Chaos Monkey is enabled"));
+    ZonedDateTime enabledAt = ZonedDateTime.now();
+    ZonedDateTime timeReturned = chaosMonkeyJmxEndpoint.enableChaosMonkey().getEnabledAt();
+    assertTrue(timeReturned.isAfter(enabledAt) || timeReturned.isEqual(enabledAt));
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(true));
   }
 
   @Test
   void disableChaosMonkey() {
-    assertThat(chaosMonkeyJmxEndpoint.disableChaosMonkey(), startsWith("Chaos Monkey is disabled"));
+    ZonedDateTime disabledAt = ZonedDateTime.now();
+    ZonedDateTime timeReturned = chaosMonkeyJmxEndpoint.disableChaosMonkey().getDisabledAt();
+    assertTrue(timeReturned.isAfter(disabledAt) || timeReturned.isEqual(disabledAt));
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(false));
   }
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
@@ -17,8 +17,8 @@
 
 package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -278,7 +278,9 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
         testRestTemplate.postForEntity(baseUrl + "/enable", null, ChaosMonkeyEnabledDto.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertTrue(Objects.requireNonNull(result.getBody()).getEnabledAt().isAfter(enabledAt));
+    assertThat(Objects.requireNonNull(result.getBody()).getStatus())
+        .isEqualTo("Chaos Monkey is enabled");
+    assertThat(Objects.requireNonNull(result.getBody()).getEnabledAt()).isAfterOrEqualTo(enabledAt);
   }
 
   // DISABLE CHAOS MONKEY
@@ -289,7 +291,10 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
         testRestTemplate.postForEntity(baseUrl + "/disable", null, ChaosMonkeyDisabledDto.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertTrue(Objects.requireNonNull(result.getBody()).getDisabledAt().isAfter(disabledAt));
+    assertThat(Objects.requireNonNull(result.getBody()).getStatus())
+        .isEqualTo("Chaos Monkey is disabled");
+    assertThat(Objects.requireNonNull(result.getBody()).getDisabledAt())
+        .isAfterOrEqualTo(disabledAt);
   }
 
   private ResponseEntity<String> postChaosMonkeySettings(ChaosMonkeySettings chaosMonkeySettings) {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
@@ -18,6 +18,7 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,6 +31,7 @@ import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.WatcherPropertiesUpdate;
 import de.codecentric.spring.boot.demo.chaos.monkey.ChaosDemoApplication;
+import java.util.Objects;
 import lombok.Data;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -273,7 +275,7 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
         testRestTemplate.postForEntity(baseUrl + "/enable", null, String.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertEquals("Chaos Monkey is enabled", result.getBody());
+    assertTrue(Objects.requireNonNull(result.getBody()).startsWith("Chaos Monkey is enabled"));
   }
 
   // DISABLE CHAOS MONKEY
@@ -284,7 +286,7 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
         testRestTemplate.postForEntity(baseUrl + "/disable", null, String.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertEquals("Chaos Monkey is disabled", result.getBody());
+    assertTrue(Objects.requireNonNull(result.getBody()).startsWith("Chaos Monkey is disabled"));
   }
 
   private ResponseEntity<String> postChaosMonkeySettings(ChaosMonkeySettings chaosMonkeySettings) {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
@@ -29,8 +29,11 @@ import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyProperti
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyDisabledDto;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.ChaosMonkeyEnabledDto;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.WatcherPropertiesUpdate;
 import de.codecentric.spring.boot.demo.chaos.monkey.ChaosDemoApplication;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import lombok.Data;
 import org.junit.jupiter.api.BeforeEach;
@@ -270,23 +273,23 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
 
   @Test
   void postToEnableChaosMonkey() {
-
-    ResponseEntity<String> result =
-        testRestTemplate.postForEntity(baseUrl + "/enable", null, String.class);
+    ZonedDateTime enabledAt = ZonedDateTime.now();
+    ResponseEntity<ChaosMonkeyEnabledDto> result =
+        testRestTemplate.postForEntity(baseUrl + "/enable", null, ChaosMonkeyEnabledDto.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertTrue(Objects.requireNonNull(result.getBody()).startsWith("Chaos Monkey is enabled"));
+    assertTrue(Objects.requireNonNull(result.getBody()).getEnabledAt().isAfter(enabledAt));
   }
 
   // DISABLE CHAOS MONKEY
   @Test
   void postToDisableChaosMonkey() {
-
-    ResponseEntity<String> result =
-        testRestTemplate.postForEntity(baseUrl + "/disable", null, String.class);
+    ZonedDateTime disabledAt = ZonedDateTime.now();
+    ResponseEntity<ChaosMonkeyDisabledDto> result =
+        testRestTemplate.postForEntity(baseUrl + "/disable", null, ChaosMonkeyDisabledDto.class);
 
     assertEquals(HttpStatus.OK, result.getStatusCode());
-    assertTrue(Objects.requireNonNull(result.getBody()).startsWith("Chaos Monkey is disabled"));
+    assertTrue(Objects.requireNonNull(result.getBody()).getDisabledAt().isAfter(disabledAt));
   }
 
   private ResponseEntity<String> postChaosMonkeySettings(ChaosMonkeySettings chaosMonkeySettings) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added timestamp to response message when enable/disable chaos monkey with the endpoints `/chaosmonkey/enable` and `/chaosmonkey/disable`.
Modified test cases for `enableChaosMonkey()` and  ` disableChaosMonkey()` methods in order to handle timestamp now being present.

<!-- Why are these changes necessary? -->

**Why**:
https://github.com/codecentric/chaos-monkey-spring-boot/issues/246#issuecomment-885985299
<!-- How were these changes implemented? -->

**How**:
Using java.time.Clock to get current time of user and attaching it to the already present "Chaos Monkey is enabled/disabled" message.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added `N/A`
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added `N/A`
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
