### PR TITLE
Exclude GenericFilterBean from proxying

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -6,6 +6,7 @@ Built with Spring Boot {spring-boot-version}
 === Bug Fixes
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/252[#252] Update Maven Wrapper from 0.5.5 to 0.5.6.
 - https://github.com/codecentric/chaos-monkey-spring-boot/pull/251[#251] Fix missing AssaultPropertiesUpdate validation.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/261[#261] Fix crash when GenericFilterBean Component exists.
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Improvements

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/aspect/ChaosMonkeyBaseAspect.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/aspect/ChaosMonkeyBaseAspect.java
@@ -28,7 +28,12 @@ abstract class ChaosMonkeyBaseAspect {
   @Pointcut("!within(is(FinalType)) || within(com.sun.proxy.*)")
   public void nonFinalOrJdkProxiedClassPointcut() {}
 
-  @Pointcut("nonFinalOrJdkProxiedClassPointcut() && execution(* *.*(..))")
+  // GenericFilterBean cannot be proxied due to final init method.
+  @Pointcut("this(org.springframework.web.filter.GenericFilterBean)")
+  public void isBlackListedPointcut() {}
+
+  @Pointcut(
+      "!isBlackListedPointcut() && nonFinalOrJdkProxiedClassPointcut() && execution(* *.*(..))")
   public void allPublicMethodPointcut() {}
 
   @Pointcut(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Excludes GenericFilterBean from proxying

<!-- Why are these changes necessary? -->

**Why**: GenericFilterBean will throw an exception when proxied due to a final init method. See also #205

<!-- How were these changes implemented? -->

**How**: Blcklist Pointcut to exclude GenericFilterBean

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

N/A Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [X] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- N/A Tests added
      <!-- Thank you so much for that! -->
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
