### PR TITLE
Endpoint minutes active

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -7,6 +7,7 @@ Built with Spring Boot {spring-boot-version}
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Improvements
+   - https://github.com/codecentric/chaos-monkey-spring-boot/pull/286[#286] Added duration to Chaos Monkey enable/disable endpoint timestamp.
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === New Features
@@ -14,7 +15,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Contributors
 This release was only possible because of these great humans ❤️:
-
+ - https://github.com/MatthewBerk[@MatthewBerk]
 // - https://github.com/octocat[@octocat]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyJmxEndpoint.java
@@ -31,6 +31,10 @@ public class ChaosMonkeyJmxEndpoint {
 
   private final ChaosMonkeySettings chaosMonkeySettings;
 
+  private ChaosMonkeyEnabledDto chaosMonkeyEnabledDto;
+
+  private ChaosMonkeyDisabledDto chaosMonkeyDisabledDto;
+
   public ChaosMonkeyJmxEndpoint(ChaosMonkeySettings chaosMonkeySettings) {
     this.chaosMonkeySettings = chaosMonkeySettings;
   }
@@ -79,14 +83,26 @@ public class ChaosMonkeyJmxEndpoint {
 
   @WriteOperation
   public ChaosMonkeyEnabledDto enableChaosMonkey() {
-    this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return new ChaosMonkeyEnabledDto();
+    if (!this.chaosMonkeySettings.getChaosMonkeyProperties().isEnabled()
+        || chaosMonkeyEnabledDto == null) {
+      chaosMonkeyEnabledDto = new ChaosMonkeyEnabledDto();
+      this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
+    }
+    return chaosMonkeyEnabledDto;
   }
 
   @WriteOperation
   public ChaosMonkeyDisabledDto disableChaosMonkey() {
-    this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return new ChaosMonkeyDisabledDto();
+    if (this.chaosMonkeySettings.getChaosMonkeyProperties().isEnabled()
+        || chaosMonkeyDisabledDto == null) {
+      if (chaosMonkeyEnabledDto == null) {
+        chaosMonkeyDisabledDto = new ChaosMonkeyDisabledDto();
+      } else {
+        chaosMonkeyDisabledDto = new ChaosMonkeyDisabledDto(chaosMonkeyEnabledDto);
+      }
+      this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
+    }
+    return chaosMonkeyDisabledDto;
   }
 
   @ReadOperation

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRestEndpoint.java
@@ -42,6 +42,10 @@ public class ChaosMonkeyRestEndpoint {
 
   private final ChaosMonkeyScheduler scheduler;
 
+  private ChaosMonkeyEnabledDto chaosMonkeyEnabledDto;
+
+  private ChaosMonkeyDisabledDto chaosMonkeyDisabledDto;
+
   public ChaosMonkeyRestEndpoint(
       ChaosMonkeySettings chaosMonkeySettings,
       ChaosMonkeyRuntimeScope runtimeScope,
@@ -72,14 +76,26 @@ public class ChaosMonkeyRestEndpoint {
 
   @PostMapping("/enable")
   public ResponseEntity<ChaosMonkeyEnabledDto> enableChaosMonkey() {
-    this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
-    return ResponseEntity.ok().body(new ChaosMonkeyEnabledDto());
+    if (!this.chaosMonkeySettings.getChaosMonkeyProperties().isEnabled()
+        || chaosMonkeyEnabledDto == null) {
+      chaosMonkeyEnabledDto = new ChaosMonkeyEnabledDto();
+      this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(true);
+    }
+    return ResponseEntity.ok().body(chaosMonkeyEnabledDto);
   }
 
   @PostMapping("/disable")
   public ResponseEntity<ChaosMonkeyDisabledDto> disableChaosMonkey() {
-    this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
-    return ResponseEntity.ok().body(new ChaosMonkeyDisabledDto());
+    if (this.chaosMonkeySettings.getChaosMonkeyProperties().isEnabled()
+        || chaosMonkeyDisabledDto == null) {
+      if (chaosMonkeyEnabledDto == null) {
+        chaosMonkeyDisabledDto = new ChaosMonkeyDisabledDto();
+      } else {
+        chaosMonkeyDisabledDto = new ChaosMonkeyDisabledDto(chaosMonkeyEnabledDto);
+      }
+      this.chaosMonkeySettings.getChaosMonkeyProperties().setEnabled(false);
+    }
+    return ResponseEntity.ok().body(chaosMonkeyDisabledDto);
   }
 
   @GetMapping

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyDisabledDto.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyDisabledDto.java
@@ -1,10 +1,52 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import lombok.Data;
 
 @Data
 public class ChaosMonkeyDisabledDto {
   private final String status = "Chaos Monkey is disabled";
-  private ZonedDateTime disabledAt = ZonedDateTime.now();
+  private final ZonedDateTime disabledAt = ZonedDateTime.now();
+  @JsonIgnore private Duration timeActive;
+  @JsonIgnore private Duration timeInActive;
+  private String timeActiveFormatted;
+  private String timeInActiveFormatted;
+
+  public ChaosMonkeyDisabledDto() {
+    this.timeActive = Duration.ZERO;
+  }
+
+  public ChaosMonkeyDisabledDto(ChaosMonkeyEnabledDto chaosMonkeyEnabledDto) {
+    this.timeActive = chaosMonkeyEnabledDto.getTimeActive();
+  }
+
+  public Duration getTimeInActive() {
+    timeInActive = Duration.between(disabledAt, ZonedDateTime.now());
+    return timeInActive;
+  }
+
+  public String getTimeActiveFormatted() {
+    return formatDuration(timeActive);
+  }
+
+  public String getTimeInActiveFormatted() {
+    return formatDuration(getTimeInActive());
+  }
+
+  private String formatDuration(Duration duration) {
+    long inSeconds = duration.getSeconds();
+    long secondsPart = inSeconds % 60;
+    long minutesPart = (inSeconds % 3600) / 60;
+
+    if (duration.toHours() > 0) {
+      return String.format(
+          "%d hours %02d minutes %02d seconds", duration.toHours(), minutesPart, secondsPart);
+    } else if (duration.toMinutes() > 0) {
+      return String.format("%d minutes %02d seconds", duration.toMinutes(), secondsPart);
+    } else {
+      return String.format("%d seconds", inSeconds);
+    }
+  }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyEnabledDto.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/ChaosMonkeyEnabledDto.java
@@ -1,10 +1,38 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import lombok.Data;
 
 @Data
 public class ChaosMonkeyEnabledDto {
   private final String status = "Chaos Monkey is enabled";
-  private ZonedDateTime enabledAt = ZonedDateTime.now();
+  private final ZonedDateTime enabledAt = ZonedDateTime.now();
+  @JsonIgnore private Duration timeActive;
+  private String timeActiveFormatted;
+
+  public Duration getTimeActive() {
+    timeActive = Duration.between(enabledAt, ZonedDateTime.now());
+    return timeActive;
+  }
+
+  public String getTimeActiveFormatted() {
+    return formatDuration(getTimeActive());
+  }
+
+  private String formatDuration(Duration duration) {
+    long inSeconds = duration.getSeconds();
+    long secondsPart = inSeconds % 60;
+    long minutesPart = (inSeconds % 3600) / 60;
+
+    if (duration.toHours() > 0) {
+      return String.format(
+          "%d hours %02d minutes %02d seconds", duration.toHours(), minutesPart, secondsPart);
+    } else if (duration.toMinutes() > 0) {
+      return String.format("%d minutes %02d seconds", duration.toMinutes(), secondsPart);
+    } else {
+      return String.format("%d seconds", inSeconds);
+    }
+  }
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeJmxEndpointTest.java
@@ -111,6 +111,7 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
     ChaosMonkeyEnabledDto enabledDto = chaosMonkeyJmxEndpoint.enableChaosMonkey();
     assertThat(enabledDto.getStatus()).isEqualTo("Chaos Monkey is enabled");
     assertThat(enabledDto.getEnabledAt()).isAfterOrEqualTo(enabledAt);
+    assertThat(enabledDto.getTimeActive().getSeconds()).isZero();
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(true));
   }
 
@@ -120,6 +121,8 @@ class ChaosMonkeyRequestScopeJmxEndpointTest {
     ChaosMonkeyDisabledDto disabledDto = chaosMonkeyJmxEndpoint.disableChaosMonkey();
     assertThat(disabledDto.getStatus()).isEqualTo("Chaos Monkey is disabled");
     assertThat(disabledDto.getDisabledAt()).isAfterOrEqualTo(disabledAt);
+    assertThat(disabledDto.getTimeActive()).isZero();
+    assertThat(disabledDto.getTimeInActive().getSeconds()).isZero();
     assertThat(chaosMonkeySettings.getChaosMonkeyProperties().isEnabled(), is(false));
   }
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/endpoints/ChaosMonkeyRequestScopeRestEndpointIntegration.java
@@ -281,6 +281,7 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
     assertThat(Objects.requireNonNull(result.getBody()).getStatus())
         .isEqualTo("Chaos Monkey is enabled");
     assertThat(Objects.requireNonNull(result.getBody()).getEnabledAt()).isAfterOrEqualTo(enabledAt);
+    assertThat(Objects.requireNonNull(result.getBody()).getTimeActive().getSeconds()).isZero();
   }
 
   // DISABLE CHAOS MONKEY
@@ -295,6 +296,8 @@ class ChaosMonkeyRequestScopeRestEndpointIntegration {
         .isEqualTo("Chaos Monkey is disabled");
     assertThat(Objects.requireNonNull(result.getBody()).getDisabledAt())
         .isAfterOrEqualTo(disabledAt);
+    assertThat(Objects.requireNonNull(result.getBody()).getTimeActive()).isZero();
+    assertThat(Objects.requireNonNull(result.getBody()).getTimeInActive().getSeconds()).isZero();
   }
 
   private ResponseEntity<String> postChaosMonkeySettings(ChaosMonkeySettings chaosMonkeySettings) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added a time active and time inactive duration to the Enable/Disable endpoint timestamps.
Edited ChaosMonkeyDisabledDto and ChaosMonkeyEnabledDto to track duration Chaos Monkey was enabled and disabled for current enabled/disabled session.
Modified test cases for `enableChaosMonkey()` and `disableChaosMonkey()` methods in order to handle duration.
<!-- Why are these changes necessary? -->

**Why**:
https://github.com/codecentric/chaos-monkey-spring-boot/issues/258
<!-- How were these changes implemented? -->

**How**:
Using java.time.Duration to calculate duration since ChaosMonkeyDisabledDto and ChaosMonkeyEnabledDto was created. Every time Chaos Monkey is enabled after being disabled and vice versa, a new instance of EnabledDto/DisabledDto is created since it represents current active and inactive session!
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
