### PR TITLE
Implemented the ability to use static factory methods for property cr…

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/endpoints.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/endpoints.adoc
@@ -292,6 +292,31 @@ Assault config has changed
 ----
 Assault config has changed
 ----
+====== Define custom Exceptions Without Constructors
+This is an example of configuration an exception which doesn't use a constructor, but instead uses a static factory method for creation.
+[source,json,subs="verbatim,attributes"]
+./chasomonkey/assaults - Request
+----
+{
+  "level": 5,
+  "latencyRangeStart": 2000,
+  "latencyRangeEnd": 5000,
+  "latencyActive": true,
+  "exceptionsActive": true,
+  "killApplicationActive": false,
+  "exception": {
+    "type": "com.foo.SomeCustomException",
+    "arguments": [
+      {
+        "useFactoryMethod": true,
+        "factoryMethodName": "fromStatusCode",
+        "className": "int",
+        "value": "2"
+      }
+    ]
+  }
+}
+----
 
 ==== POST Assault Attack
 [[assaultsattack]]

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/ExceptionAssaultTest.java
@@ -20,9 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import de.codecentric.spring.boot.chaos.monkey.component.MetricEventPublisher;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
+import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException.ExceptionArgument;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -110,6 +112,28 @@ class ExceptionAssaultTest {
 
     ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
     assertThrows(OutOfMemoryError.class, exceptionAssault::attack);
+  }
+
+  @Test
+  void throwsExceptionWithPrivateConstructorValueObjects() {
+    ChaosMonkeySettings settings = getChaosMonkeySettings();
+
+    AssaultException assaultException = new AssaultException();
+    assaultException.setType(
+        "de.codecentric.spring.boot.chaos.monkey.assaults.StatusExampleException");
+
+    ExceptionArgument argument = new ExceptionArgument();
+    argument.setClassName("de.codecentric.spring.boot.chaos.monkey.assaults.Status");
+    argument.setUseFactoryMethod(true);
+    argument.setFactoryMethodName("fromCodeValue");
+    argument.setValueClassName("int");
+    argument.setValue("2");
+
+    assaultException.setArguments(Arrays.asList(argument));
+
+    settings.getAssaultProperties().setException(assaultException);
+    ExceptionAssault exceptionAssault = new ExceptionAssault(settings, metricsMock);
+    assertThrows(StatusExampleException.class, exceptionAssault::attack);
   }
 
   private ChaosMonkeySettings getChaosMonkeySettings() {

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/Status.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/Status.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package de.codecentric.spring.boot.chaos.monkey.assaults;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+
+/*
+ * This Status class is used as an example of a class with no public constructors
+ * but instead leverages static "factory" methods for creation.
+ *
+ * This particular example is based off of exceptions thrown by the grpc-java project.
+ */
+public final class Status {
+
+  public static Status fromCodeValue(int codeValue) {
+    return STATUS_LIST.get(codeValue);
+  }
+
+  private static List<Status> buildStatusList() {
+    TreeMap<Integer, Status> canonicalizer = new TreeMap<>();
+    for (Code code : Code.values()) {
+      Status replaced = canonicalizer.put(code.value(), new Status(code));
+      if (replaced != null) {
+        throw new IllegalStateException(
+            "Code value duplication between " + replaced.getCode().name() + " & " + code.name());
+      }
+    }
+    return Collections.unmodifiableList(new ArrayList<>(canonicalizer.values()));
+  }
+
+  public static final List<Status> STATUS_LIST = buildStatusList();
+
+  public enum Code {
+    OK(0),
+    UNKNOWN(1),
+    NOT_FOUND(2);
+
+    private final int value;
+
+    Code(int value) {
+      this.value = value;
+    }
+
+    public int value() {
+      return value;
+    }
+
+    public Status toStatus() {
+      return STATUS_LIST.get(value);
+    }
+  }
+
+  private final Code code;
+
+  private Status(Code code) {
+    this.code = code;
+  }
+
+  public Code getCode() {
+    return code;
+  }
+
+  public static final Status OK = Code.OK.toStatus();
+  public static final Status UNKNOWN = Code.UNKNOWN.toStatus();
+  public static final Status NOT_FOUND = Code.NOT_FOUND.toStatus();
+
+
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/Status.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/Status.java
@@ -80,6 +80,4 @@ public final class Status {
   public static final Status OK = Code.OK.toStatus();
   public static final Status UNKNOWN = Code.UNKNOWN.toStatus();
   public static final Status NOT_FOUND = Code.NOT_FOUND.toStatus();
-
-
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/StatusExampleException.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/assaults/StatusExampleException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package de.codecentric.spring.boot.chaos.monkey.assaults;
+
+/*
+ * This exception has a required parameter that has no public constructors.
+ * Instead, static methods are used.
+ */
+public class StatusExampleException extends RuntimeException {
+
+  private final Status statusCode;
+
+  public StatusExampleException(Status statusCode) {
+    super();
+    this.statusCode = statusCode;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add an ability to create exception assaults that use exceptions that do not have a public constructor for creation.

<!-- Why are these changes necessary? -->

**Why**: Some third-party libraries that throw custom exceptions created using a static factory method.  This allows for the creation of assaults that use this style of class.

<!-- How were these changes implemented? -->

**How**:

Added some additional properties on the exception argument class that allows for specifying a creation method to use to generate the exception class.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ ] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [X] Tests added
      <!-- Thank you so much for that! -->
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Let me know if there are changes you'd like to see made.  This change greatly increases the style and types of exceptions that can be thrown.