### PR TITLE
change bean name from scheduler to chaosMonkeyScheduler

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -159,7 +159,7 @@ public class ChaosMonkeyConfiguration {
   }
 
   @Bean
-  public ChaosMonkeyScheduler scheduler(
+  public ChaosMonkeyScheduler chaosMonkeyScheduler(
       @Qualifier(CHAOS_MONKEY_TASK_SCHEDULER) TaskScheduler scheduler,
       List<ChaosMonkeyRuntimeAssault> assaults) {
     ScheduledTaskRegistrar registrar = new ScheduledTaskRegistrar();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Rename scheduler bean

<!-- Why are these changes necessary? -->

**Why**:
Bean name collisions with [db-scheduler](https://github.com/kagkarlsson/db-scheduler).
See issue #292 

<!-- How were these changes implemented? -->

<!-- **How**: -->

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ ] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
