### PR TITLE
Add actuator health watcher property to documentation

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -8,7 +8,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-- https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added Spring actuator health watcher property to documentation.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/320[#320] Added Spring actuator health watcher property to documentation.
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -8,6 +8,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added Spring actuator health watcher property to documentation.
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -16,5 +17,6 @@ Built with Spring Boot {spring-boot-version}
 This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/ZengLawrence[@ZengLawrence]
 
 Thank you for your support!

--- a/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
@@ -172,6 +172,11 @@ You can decide which attacks you want to run and which parts of your application
 |TRUE or FALSE
 |FALSE
 
+|chaos.monkey.watcher.actuatorHealth
+|Spring actuator health watcher active
+|TRUE or FALSE
+|FALSE
+
 |chaos.monkey.watcher.beans
 |Bean watcher for given beans
 |List of bean names


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add actuator health watcher property to documentation.

<!-- Why are these changes necessary? -->

**Why**:
It took me about 1/2 hour to search the documentation to find out to how to enable watcher for Spring actuator health.

<!-- How were these changes implemented? -->

**How**:
By adding to the Configuration section of the documentation.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [X] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
