### PR TITLE
Fix typo in jdbcRepositoryPointcutAdvisor bean name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,15 +7,15 @@ contributing guidelines (found in the CONTRIBUTING.adoc file).
 Please fill out the information below to expedite the review and (hopefully)
 merge of your pull request!
 -->
-<!-- What changes are being made? (What feature/bug is being fixed here?) -->
 
-**What**: <!-- Why are these changes necessary? -->
+**What**: <!-- What changes are being made? (What feature/bug is being fixed here?) -->
 
-**Why**: <!-- How were these changes implemented? -->
+**Why**: <!-- Why are these changes necessary? -->
 
-**How**: <!-- Have you done all of these things?  -->
+**How**: <!-- How were these changes implemented? -->
 
-**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes
+**Checklist**: <!-- Have you done all of these things?  -->
+<!-- add "N/A" to the end of each line that's irrelevant to your changes
 to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
 - [ ] Documentation added

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyAdvisorConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyAdvisorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,8 +104,8 @@ public class ChaosMonkeyAdvisorConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "jdbcRepositoryPointcdutAdvisor")
-    public ChaosMonkeyPointcutAdvisor jdbcRepositoryPointcdutAdvisor(ChaosMonkeyBaseClassFilter baseClassFilter, ChaosMonkeyRequestScope requestScope,
+    @ConditionalOnMissingBean(name = "jdbcRepositoryPointcutAdvisor")
+    public ChaosMonkeyPointcutAdvisor jdbcRepositoryPointcutAdvisor(ChaosMonkeyBaseClassFilter baseClassFilter, ChaosMonkeyRequestScope requestScope,
             MetricEventPublisher eventPublisher) {
         return new ChaosMonkeyAnnotationPointcutAdvisor(baseClassFilter,
                 new ChaosMonkeyDefaultAdvice(requestScope, eventPublisher, ChaosTarget.REPOSITORY, watcherProperties::isRepository),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: <!-- Why are these changes necessary? -->
There is a small typo in the bean name of jdbcRepositoryPointcutAdvisor 
**Why**: <!-- How were these changes implemented? -->
Typos dont look good :D

**How**: <!-- Have you done all of these things?  -->


**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [N/A] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
