### PR TITLE
Extend repository class filter to also match proxied repositories.

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -5,6 +5,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+* https://github.com/codecentric/chaos-monkey-spring-boot/pull/337[#337]: Jdbc repository watcher wasn't working in most cases.
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -21,5 +22,7 @@ Built with Spring Boot {spring-boot-version}
 This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
+ - https://github.com/WtfJoke[@WtfJoke]
+ - https://github.com/F43nd1r[@F43nd1r]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyAdvisorConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyAdvisorConfiguration.java
@@ -25,6 +25,7 @@ import de.codecentric.spring.boot.chaos.monkey.watcher.advice.advisor.ChaosMonke
 import de.codecentric.spring.boot.chaos.monkey.watcher.advice.advisor.ChaosMonkeyPointcutAdvisor;
 import de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter.ChaosMonkeyBaseClassFilter;
 import de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter.MethodNameFilter;
+import de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter.RepositoryAnnotatedClassFilter;
 import de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter.SpringHookMethodsFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -37,7 +38,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
-import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -107,9 +107,9 @@ public class ChaosMonkeyAdvisorConfiguration {
     @ConditionalOnMissingBean(name = "jdbcRepositoryPointcutAdvisor")
     public ChaosMonkeyPointcutAdvisor jdbcRepositoryPointcutAdvisor(ChaosMonkeyBaseClassFilter baseClassFilter, ChaosMonkeyRequestScope requestScope,
             MetricEventPublisher eventPublisher) {
-        return new ChaosMonkeyAnnotationPointcutAdvisor(baseClassFilter,
+        return new ChaosMonkeyPointcutAdvisor(baseClassFilter,
                 new ChaosMonkeyDefaultAdvice(requestScope, eventPublisher, ChaosTarget.REPOSITORY, watcherProperties::isRepository),
-                Repository.class);
+                new RepositoryAnnotatedClassFilter());
     }
 
     @Bean

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class ChaosMonkeyBaseClassFilter implements ClassFilter {
     }
 
     private boolean nonFinalOrJdkProxiedClass(Class<?> clazz) {
-        return !Modifier.isFinal(clazz.getModifiers()) || clazz.getName().startsWith("com.sun.proxy.");
+        return !Modifier.isFinal(clazz.getModifiers()) || clazz.getName().startsWith("com.sun.proxy.") || clazz.getName().startsWith("jdk.proxy2.");
     }
 
     private boolean hasProblematicFinalMethod(Class<?> clazz) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryAnnotatedClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryAnnotatedClassFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter;
+
+import org.springframework.aop.ClassFilter;
+import org.springframework.stereotype.Repository;
+
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+public class RepositoryAnnotatedClassFilter implements ClassFilter {
+    @Override
+    public boolean matches(Class<?> clazz) {
+        return clazz.isAnnotationPresent(Repository.class)
+                // if a repository is proxied by spring the annotation can only be found on the
+                // implemented interface
+                || Proxy.isProxyClass(clazz) && Arrays.stream(clazz.getInterfaces()).anyMatch(i -> i.isAnnotationPresent(Repository.class));
+    }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyRepositoryWatcherIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyRepositoryWatcherIntegrationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.watcher;
+
+import de.codecentric.spring.boot.demo.chaos.monkey.ChaosDemoApplication;
+import de.codecentric.spring.boot.demo.chaos.monkey.repository.CrudDemoRepository;
+import de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepository;
+import de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepositoryJDBC;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+@SpringBootTest(properties = {"chaos.monkey.watcher.repository=true", "chaos.monkey.assaults.exceptions-active=true",
+        "chaos.monkey.enabled=true"}, classes = {ChaosDemoApplication.class})
+@ActiveProfiles("chaos-monkey")
+public class ChaosMonkeyRepositoryWatcherIntegrationTest {
+
+    @Autowired
+    private CrudDemoRepository crudDemoRepository;
+
+    @Autowired
+    private DemoRepository demoRepository;
+
+    @Autowired
+    private DemoRepositoryJDBC demoRepositoryJDBC;
+
+    @Test
+    public void testIfCrudRepositoryCallThrowsException() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(crudDemoRepository::count);
+    }
+
+    @Test
+    public void testIfDemoRepositoryCallThrowsException() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(demoRepository::count);
+    }
+
+    @Test
+    public void testIfDemoRepositoryJDBCCallThrowsException() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(demoRepositoryJDBC::sayHello);
+    }
+}


### PR DESCRIPTION
Closes #335


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: <!-- What changes are being made? (What feature/bug is being fixed here?) -->
Extend repository class filter to also match proxied repositories.
Add test to prevent regressions.

**Why**: <!-- Why are these changes necessary? -->
See #335  - jdbc repositories were potentially not matched.

**How**: <!-- How were these changes implemented? -->
Pass on final proxies in jdk.proxy2.* in base filter to allow accepting proxied repositories.
Check directly `@Repository` annotated classes as done previously, but also check for annotations on interfaces in case of proxies.

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- N/A Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [X] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
