### PR TITLE
Improve uniqueness of beans provided by Chaos Monkey (see #339)

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -5,7 +5,8 @@ Built with Spring Boot {spring-boot-version}
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
-* https://github.com/codecentric/chaos-monkey-spring-boot/pull/337[#337]: Jdbc repository watcher wasn't working in most cases.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/337[#337]: Jdbc repository watcher wasn't working in most cases.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/340[#340] Improve uniqueness of beans provided by Chaos Monkey
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,17 +81,17 @@ public class ChaosMonkeyConfiguration {
 
     @Bean
     @ConditionalOnClass(name = "io.micrometer.core.instrument.MeterRegistry")
-    public Metrics metrics() {
+    public Metrics chaosMonkeyMetrics() {
         return new Metrics();
     }
 
     @Bean
-    public MetricEventPublisher publisher() {
+    public MetricEventPublisher chaosMonkeyMetricsPublisher() {
         return new MetricEventPublisher();
     }
 
     @Bean
-    public ChaosMonkeySettings settings() {
+    public ChaosMonkeySettings chaosMonkeySettings() {
         return new ChaosMonkeySettings(chaosMonkeyProperties, assaultProperties, watcherProperties);
     }
 

--- a/demo-apps/chaos-monkey-demo-app-naked/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
+++ b/demo-apps/chaos-monkey-demo-app-naked/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,6 @@ public class ChaosDemoApplicationTests {
 
     @Test
     public void checkNotMetricsBean() {
-        assertThrows(NoSuchBeanDefinitionException.class, () -> ctx.getBean("metrics"), "No bean named 'metrics' available");
+        assertThrows(NoSuchBeanDefinitionException.class, () -> ctx.getBean("chaosMonkeyMetrics"), "No bean named 'metrics' available");
     }
 }

--- a/demo-apps/chaos-monkey-demo-app-unleash-toggles/src/test/java/com/example/chaos/monkey/toggledemo/ChaosDemoApplicationTests.java
+++ b/demo-apps/chaos-monkey-demo-app-unleash-toggles/src/test/java/com/example/chaos/monkey/toggledemo/ChaosDemoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ public class ChaosDemoApplicationTests {
 
     @Test
     public void checkMetricsBean() {
-        assertThat(ctx.getBean("metrics")).isNotNull();
+        assertThat(ctx.getBean("chaosMonkeyMetrics")).isNotNull();
     }
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ public class ChaosDemoApplicationTests {
 
     @Test
     public void checkMetricsBean() {
-        assertThat(ctx.getBean("metrics")).isNotNull();
+        assertThat(ctx.getBean("chaosMonkeyMetrics")).isNotNull();
     }
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/HelloComponentIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/HelloComponentIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class HelloComponentIntegrationTest {
 
     @Test
     public void callingPublicMethodOnComponent() {
-        assertTrue(chaosMonkeyConfiguration.settings().getWatcherProperties().isComponent());
+        assertTrue(chaosMonkeyConfiguration.chaosMonkeySettings().getWatcherProperties().isComponent());
 
         helloComponent.sayHello();
     }

--- a/demo-apps/chaos-monkey-web-reactive-app/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
+++ b/demo-apps/chaos-monkey-web-reactive-app/src/test/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ public class ChaosDemoApplicationTests {
 
     @Test
     public void checkMetricsBean() {
-        assertThat(ctx.getBean("metrics")).isNotNull();
+        assertThat(ctx.getBean("chaosMonkeyMetrics")).isNotNull();
     }
 }


### PR DESCRIPTION
To avoid BeanDefinitionOverrideException in users application code, we should aim for unique bean names.

By prefixing the (common) bean names with chaos monkey it should be unique enough.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: <!-- What changes are being made? (What feature/bug is being fixed here?) -->
#339 
**Why**: <!-- Why are these changes necessary? -->
To avoid BeanOverrideException in our users application code.
**How**: <!-- How were these changes implemented? -->
By prefixing the common bean names with `chaosMonkey`
**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [N/A] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
