### PR TITLE
Increment level only for methods/classes/packages listed in WatchedCustomServices (instead of every watched method/class/package)

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -1,13 +1,14 @@
 [[changes]]
-== Changes in {project-version}
+== Changes in 3.1.1
 
-Built with Spring Boot {spring-boot-version}
+Built with Spring Boot 3.2.3
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- Increment level count exclusively for methods, classes or packages listed in WatchedCustomServices
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -16,5 +17,6 @@ Built with Spring Boot {spring-boot-version}
 This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/eshaanganesh2[@eshaanganesh2]
 
 Thank you for your support!

--- a/chaos-monkey-docs/src/main/asciidoc/faq.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/faq.adoc
@@ -53,5 +53,11 @@ To prevent these classes from being proxied, you can either:
  - mark them as final
  - don't mark them as spring `@Component` (or `@Service`, `@Controller`, ...). Instead, register them as `@Bean` inside a configuration.
 
+=== My classes (or methods or packages) do not get assaulted after setting the WatchedCustomServices property
+
+ - Ensure that the associated watcher property for the class/method/package is set to true
+ - Ensure that the fully qualified path of the class/method/package is set accurately
+
+
 
 

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,21 @@ class ChaosMonkeyRequestScopeTest {
         given(chaosMonkeyProperties.isEnabled()).willReturn(false);
 
         chaosMonkeyRequestScope.callChaosMonkey(null, null);
+
+        verify(latencyAssault, never()).attack();
+        verify(exceptionAssault, never()).attack();
+    }
+
+    @Test
+    void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
+        String customService = "CustomService";
+
+        given(chaosMonkeyProperties.isEnabled()).willReturn(true);
+        given(chaosMonkeySettings.getAssaultProperties()).willReturn(assaultProperties);
+        given(assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
+        given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
+
+        chaosMonkeyRequestScope.callChaosMonkey(null, "notInListService");
 
         verify(latencyAssault, never()).attack();
         verify(exceptionAssault, never()).attack();
@@ -191,19 +206,6 @@ class ChaosMonkeyRequestScopeTest {
             given(assaultProperties.getTroubleRandom()).willReturn(9);
 
             chaosMonkeyRequestScope.callChaosMonkey(null, null);
-
-            verify(latencyAssault, never()).attack();
-            verify(exceptionAssault, never()).attack();
-        }
-
-        @Test
-        void chaosMonkeyIsNotCalledWhenServiceNotWatched() {
-            String customService = "CustomService";
-
-            given(assaultProperties.getWatchedCustomServices()).willReturn(Collections.singletonList(customService));
-            given(chaosMonkeySettings.getAssaultProperties().isWatchedCustomServicesActive()).willReturn(true);
-
-            chaosMonkeyRequestScope.callChaosMonkey(null, "notInListService");
 
             verify(latencyAssault, never()).attack();
             verify(exceptionAssault, never()).attack();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: <!-- What changes are being made? (What feature/bug is being fixed here?) -->
The level count increases every time we encounter a watched method, class, or package, regardless of whether it's present in the WatchedCustomServices list or not. Through this PR, I have made some changes to instead increase the level count only when a watched method (or class or package) is listed in WatchedCustomServices. 
**More details on this can be found at https://github.com/codecentric/chaos-monkey-spring-boot/issues/451** 

**Why**: <!-- Why are these changes necessary? -->
These changes would help improve predictability wherein only methods/classes/packages listed within the WatchedCustomServices would increase level counts, as opposed to any and every watched method doing the same.

**How**: <!-- How were these changes implemented? -->
Changes have been made within the logic of `callChaosMonkey(ChaosTarget type, String simpleName)` function present in the `ChaosMonkeyRequestScope.java` file. 
A check has been implemented to verify if WatchedCustomServices  is active and if the exact same method is present in WatchedCustomServices . If yes, only then the level count is incremented.

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
