### PR TITLE
395 spring retry recover method not getting called in case of exception assault on service class

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -11,6 +11,7 @@ Built with Spring Boot {spring-boot-version}
 
 === New Features
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/issues/395 Recover method should be called in case of service assault.
 
 === Contributors
 This release was only possible because of these great humans ❤️:

--- a/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
@@ -51,6 +51,11 @@ You can decide which attacks you want to run and which parts of your application
 |TRUE or FALSE
 |FALSE
 
+|chaos.monkey.assaults.exceptions-ignored-on-recover.
+|Exceptionignored on `@Recover` annotated methods
+|TRUE or FALSE
+|FALSE
+
 |chaos.monkey.assaults.exception.type
 |Exception to be thrown
 |Class name

--- a/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/configuration.adoc
@@ -52,7 +52,7 @@ You can decide which attacks you want to run and which parts of your application
 |FALSE
 
 |chaos.monkey.assaults.exceptions-ignored-on-recover.
-|Exceptionignored on `@Recover` annotated methods
+|Exception ignored on `@Recover` annotated methods
 |TRUE or FALSE
 |FALSE
 

--- a/chaos-monkey-spring-boot/pom.xml
+++ b/chaos-monkey-spring-boot/pom.xml
@@ -121,6 +121,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>2.0.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,22 +20,28 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 import de.codecentric.spring.boot.chaos.monkey.assaults.ChaosMonkeyAssault;
 import de.codecentric.spring.boot.chaos.monkey.assaults.ChaosMonkeyRequestAssault;
 import de.codecentric.spring.boot.chaos.monkey.assaults.ChaosMonkeyRuntimeAssault;
+import de.codecentric.spring.boot.chaos.monkey.assaults.ExceptionAssault;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeySettings;
+import de.codecentric.spring.boot.chaos.monkey.configuration.MethodFilter;
 import de.codecentric.spring.boot.chaos.monkey.configuration.toggles.ChaosToggleNameMapper;
 import de.codecentric.spring.boot.chaos.monkey.configuration.toggles.ChaosToggles;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * @author Benjamin Wilms
  */
+@Slf4j
 public class ChaosMonkeyRequestScope {
 
     private final ChaosMonkeySettings chaosMonkeySettings;
@@ -47,16 +53,14 @@ public class ChaosMonkeyRequestScope {
     private final MetricEventPublisher metricEventPublisher;
 
     private final AtomicInteger assaultCounter;
+    private final MethodFilter methodFilter;
 
     public ChaosMonkeyRequestScope(ChaosMonkeySettings chaosMonkeySettings, List<ChaosMonkeyRequestAssault> assaults,
-            List<ChaosMonkeyAssault> legacyAssaults, MetricEventPublisher metricEventPublisher, ChaosToggles chaosToggles,
-            ChaosToggleNameMapper chaosToggleNameMapper) {
-        List<RequestAssaultAdapter> assaultAdapters = legacyAssaults.stream()
-                .filter(it -> !(it instanceof ChaosMonkeyRequestAssault || it instanceof ChaosMonkeyRuntimeAssault)).map(RequestAssaultAdapter::new)
-                .toList();
-        List<ChaosMonkeyRequestAssault> requestAssaults = new ArrayList<>();
-        requestAssaults.addAll(assaults);
-        requestAssaults.addAll(assaultAdapters);
+                                   List<ChaosMonkeyAssault> legacyAssaults, MetricEventPublisher metricEventPublisher, ChaosToggles chaosToggles,
+                                   ChaosToggleNameMapper chaosToggleNameMapper, MethodFilter methodFilter) {
+        this.methodFilter = methodFilter;
+        List<ChaosMonkeyRequestAssault> requestAssaults = new ArrayList<>(assaults);
+        requestAssaults.addAll(getLegacyAssaults(legacyAssaults));
 
         this.chaosMonkeySettings = chaosMonkeySettings;
         this.assaults = requestAssaults;
@@ -66,51 +70,61 @@ public class ChaosMonkeyRequestScope {
         this.assaultCounter = new AtomicInteger(0);
     }
 
-    public void callChaosMonkey(ChaosTarget type, String simpleName) {
-        if (isEnabled(type, simpleName) && isTrouble()) {
+    private static List<RequestAssaultAdapter> getLegacyAssaults(List<ChaosMonkeyAssault> legacyAssaults) {
+        return legacyAssaults.stream()
+                .filter(Predicate.not(ChaosMonkeyRuntimeAssault.class::isInstance))
+                .filter(Predicate.not(ChaosMonkeyRequestAssault.class::isInstance))
+                .map(RequestAssaultAdapter::new).toList();
+    }
 
-            if (metricEventPublisher != null) {
-                metricEventPublisher.publishMetricEvent(MetricType.APPLICATION_REQ_COUNT, "type", "total");
-            }
+    public void callChaosMonkey(ChaosTarget type, String signature) {
+        callChaosMonkey(type, signature, null, null);
+    }
+
+    public void callChaosMonkey(ChaosTarget type, String signature, Object target, Method method) {
+        if (isEnabled(type, signature) && isTrouble()) {
+            metricEventPublisher.publishMetricEvent(MetricType.APPLICATION_REQ_COUNT, "type", "total");
 
             // Custom watched services can be defined at runtime, if there are any, only
             // these will be attacked!
             AssaultProperties assaultProps = chaosMonkeySettings.getAssaultProperties();
-            if (assaultProps.isWatchedCustomServicesActive()) {
-                if (assaultProps.getWatchedCustomServices().stream().anyMatch(simpleName::startsWith)) {
-                    // only all listed custom methods will be attacked
-                    chooseAndRunAttack();
-                }
-            } else {
+            if (!assaultProps.isWatchedCustomServicesActive() || assaultProps.getWatchedCustomServices().stream().anyMatch(signature::startsWith)) {
+                // only all listed custom methods will be attacked
                 // default attack if no custom watched service is defined
-                chooseAndRunAttack();
+                chooseAndRunAttack(target, method);
             }
         }
     }
 
-    private void chooseAndRunAttack() {
+    private void chooseAndRunAttack(Object target, Method method) {
         List<ChaosMonkeyAssault> activeAssaults = assaults.stream().filter(ChaosMonkeyAssault::isActive).collect(Collectors.toList());
         if (isEmpty(activeAssaults)) {
             return;
         }
-        getRandomFrom(activeAssaults).attack();
 
-        if (metricEventPublisher != null) {
-            metricEventPublisher.publishMetricEvent(MetricType.APPLICATION_REQ_COUNT, "type", "assaulted");
+        ChaosMonkeyAssault assault = getRandomFrom(activeAssaults);
+        if (target != null && method != null && assault instanceof ExceptionAssault) {
+            log.info("exception assault found");
+            if (methodFilter.filter(target, method)) {
+                log.info("recover found");
+                return;
+            }
         }
+        assault.attack();
+
+        metricEventPublisher.publishMetricEvent(MetricType.APPLICATION_REQ_COUNT, "type", "assaulted");
     }
 
-    private ChaosMonkeyAssault getRandomFrom(List<ChaosMonkeyAssault> activeAssaults) {
-        int exceptionRand = chaosMonkeySettings.getAssaultProperties().chooseAssault(activeAssaults.size());
-        return activeAssaults.get(exceptionRand);
+    private ChaosMonkeyAssault getRandomFrom(List<? extends ChaosMonkeyAssault> activeAssaults) {
+        return activeAssaults.get(chaosMonkeySettings.getAssaultProperties().chooseAssault(activeAssaults.size()));
     }
 
     private boolean isTrouble() {
-        if (chaosMonkeySettings.getAssaultProperties().isDeterministic()) {
-            return assaultCounter.incrementAndGet() % chaosMonkeySettings.getAssaultProperties().getLevel() == 0;
-        } else {
-            return chaosMonkeySettings.getAssaultProperties().getTroubleRandom() >= chaosMonkeySettings.getAssaultProperties().getLevel();
+        AssaultProperties assaultProperties = chaosMonkeySettings.getAssaultProperties();
+        if (assaultProperties.isDeterministic()) {
+            return assaultCounter.incrementAndGet() % assaultProperties.getLevel() == 0;
         }
+        return assaultProperties.getTroubleRandom() >= assaultProperties.getLevel();
     }
 
     private boolean isEnabled(ChaosTarget type, String name) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
@@ -56,8 +56,8 @@ public class ChaosMonkeyRequestScope {
     private final MethodFilter methodFilter;
 
     public ChaosMonkeyRequestScope(ChaosMonkeySettings chaosMonkeySettings, List<ChaosMonkeyRequestAssault> assaults,
-                                   List<ChaosMonkeyAssault> legacyAssaults, MetricEventPublisher metricEventPublisher, ChaosToggles chaosToggles,
-                                   ChaosToggleNameMapper chaosToggleNameMapper, MethodFilter methodFilter) {
+            List<ChaosMonkeyAssault> legacyAssaults, MetricEventPublisher metricEventPublisher, ChaosToggles chaosToggles,
+            ChaosToggleNameMapper chaosToggleNameMapper, MethodFilter methodFilter) {
         this.methodFilter = methodFilter;
         List<ChaosMonkeyRequestAssault> requestAssaults = new ArrayList<>(assaults);
         requestAssaults.addAll(getLegacyAssaults(legacyAssaults));
@@ -71,10 +71,8 @@ public class ChaosMonkeyRequestScope {
     }
 
     private static List<RequestAssaultAdapter> getLegacyAssaults(List<ChaosMonkeyAssault> legacyAssaults) {
-        return legacyAssaults.stream()
-                .filter(Predicate.not(ChaosMonkeyRuntimeAssault.class::isInstance))
-                .filter(Predicate.not(ChaosMonkeyRequestAssault.class::isInstance))
-                .map(RequestAssaultAdapter::new).toList();
+        return legacyAssaults.stream().filter(Predicate.not(ChaosMonkeyRuntimeAssault.class::isInstance))
+                .filter(Predicate.not(ChaosMonkeyRequestAssault.class::isInstance)).map(RequestAssaultAdapter::new).toList();
     }
 
     public void callChaosMonkey(ChaosTarget type, String signature) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScope.java
@@ -101,12 +101,8 @@ public class ChaosMonkeyRequestScope {
         }
 
         ChaosMonkeyAssault assault = getRandomFrom(activeAssaults);
-        if (target != null && method != null && assault instanceof ExceptionAssault) {
-            log.info("exception assault found");
-            if (methodFilter.filter(target, method)) {
-                log.info("recover found");
-                return;
-            }
+        if (target != null && method != null && assault instanceof ExceptionAssault && methodFilter.filter(target, method)) {
+            return;
         }
         assault.attack();
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -42,6 +42,7 @@ public class AssaultProperties {
 
     private boolean exceptionsActive;
 
+    @JsonIgnore
     private boolean exceptionsIgnoredOnRecover;
 
     @NestedConfigurationProperty

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,24 +32,26 @@ import org.springframework.util.CollectionUtils;
 public class AssaultProperties {
     private int level = 1;
 
-    private boolean deterministic = false;
+    private boolean deterministic;
 
     private int latencyRangeStart = 1000;
 
     private int latencyRangeEnd = 3000;
 
-    private boolean latencyActive = false;
+    private boolean latencyActive;
 
-    private boolean exceptionsActive = false;
+    private boolean exceptionsActive;
+
+    private boolean exceptionsIgnoredOnRecover;
 
     @NestedConfigurationProperty
     private AssaultException exception;
 
-    private boolean killApplicationActive = false;
+    private boolean killApplicationActive;
 
     private String killApplicationCronExpression = "OFF";
 
-    private volatile boolean memoryActive = false;
+    private volatile boolean memoryActive;
 
     private int memoryMillisecondsHoldFilledMemory = 90000;
 
@@ -61,7 +63,7 @@ public class AssaultProperties {
 
     private String memoryCronExpression = "OFF";
 
-    private volatile boolean cpuActive = false;
+    private volatile boolean cpuActive;
 
     private int cpuMillisecondsHoldLoad = 90000;
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -125,7 +125,8 @@ public class ChaosMonkeyConfiguration {
 
     @Bean
     public ChaosMonkeyRequestScope chaosMonkeyRequestScope(List<ChaosMonkeyRequestAssault> chaosMonkeyAssaults, List<ChaosMonkeyAssault> allAssaults,
-            ChaosToggles chaosToggles, ChaosToggleNameMapper chaosToggleNameMapper, ChaosMonkeySettings settings, MetricEventPublisher publisher, MethodFilter methodFilter) {
+            ChaosToggles chaosToggles, ChaosToggleNameMapper chaosToggleNameMapper, ChaosMonkeySettings settings, MetricEventPublisher publisher,
+            MethodFilter methodFilter) {
         return new ChaosMonkeyRequestScope(settings, chaosMonkeyAssaults, allAssaults, publisher, chaosToggles, chaosToggleNameMapper, methodFilter);
     }
 

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -177,6 +178,7 @@ public class ChaosMonkeyConfiguration {
 
     @Bean
     @ConditionalOnClass(Recover.class)
+    @ConditionalOnProperty(name = "chaos.monkey.assaults.exceptions-ignored-on-recover", havingValue = "true")
     public MethodFilter recoverMethodFilter() {
         return new RecoverMethodFilter();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyRestTemplateConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyRestTemplateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestT
 import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestTemplatePostProcessor;
 import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestTemplateWatcher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/MethodFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/MethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.chaos.monkey.chaosdemo;
+package de.codecentric.spring.boot.chaos.monkey.configuration;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
+import java.lang.reflect.Method;
 
-@SpringBootApplication
-@EnableRetry
-public class ChaosDemoApplication {
+public interface MethodFilter {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ChaosDemoApplication.class, args);
-    }
+    boolean filter(Object target, Method method);
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilter.java
@@ -15,13 +15,11 @@
  */
 package de.codecentric.spring.boot.chaos.monkey.configuration;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.retry.annotation.Recover;
 
 import java.lang.reflect.Method;
 
-@Slf4j
 public class RecoverMethodFilter implements MethodFilter {
     @Override
     public boolean filter(Object target, Method method) {
@@ -29,18 +27,14 @@ public class RecoverMethodFilter implements MethodFilter {
         if (recover == null) {
             recover = findAnnotationOnTarget(target, method);
         }
-        if (recover != null) {
-            log.info("recover found:{}", recover);
-            return true;
-        }
-        return false;
+        return recover != null;
     }
 
     private Recover findAnnotationOnTarget(Object target, Method method) {
         try {
             Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
             return AnnotatedElementUtils.findMergedAnnotation(targetMethod, Recover.class);
-        } catch (Exception var4) {
+        } catch (RuntimeException | NoSuchMethodException e) {
             return null;
         }
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.retry.annotation.Recover;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class RecoverMethodFilter implements MethodFilter {
+    @Override
+    public boolean filter(Object target, Method method) {
+        Recover recover = AnnotatedElementUtils.findMergedAnnotation(target.getClass(), Recover.class);
+        if (recover == null) {
+            recover = findAnnotationOnTarget(target, method);
+        }
+        if (recover != null) {
+            log.info("recover found:{}", recover);
+            return true;
+        }
+        return false;
+    }
+
+    private Recover findAnnotationOnTarget(Object target, Method method) {
+        try {
+            Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
+            return AnnotatedElementUtils.findMergedAnnotation(targetMethod, Recover.class);
+        } catch (Exception var4) {
+            return null;
+        }
+    }
+}

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/AssaultPropertiesUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.validation.AssaultExceptionConstraint;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.validation.AssaultPropertiesUpdateLatencyRangeConstraint;
 import java.util.List;
-import java.util.function.Consumer;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -129,37 +130,11 @@ public class AssaultPropertiesUpdate {
     @Nullable
     private List<String> watchedCustomServices;
 
-    private <T> void applyTo(T value, Consumer<T> setter) {
-        if (value != null) {
-            setter.accept(value);
-        }
-    }
-
     public void applyTo(AssaultProperties t) {
-        applyTo(level, t::setLevel);
-        applyTo(deterministic, t::setDeterministic);
-        applyTo(latencyActive, t::setLatencyActive);
-        applyTo(latencyRangeStart, t::setLatencyRangeStart);
-        applyTo(latencyRangeEnd, t::setLatencyRangeEnd);
-
-        applyTo(exceptionsActive, t::setExceptionsActive);
-        applyTo(exception, t::setException);
-
-        applyTo(killApplicationActive, t::setKillApplicationActive);
-        applyTo(killApplicationCronExpression, t::setKillApplicationCronExpression);
-
-        applyTo(memoryActive, t::setMemoryActive);
-        applyTo(memoryMillisecondsHoldFilledMemory, t::setMemoryMillisecondsHoldFilledMemory);
-        applyTo(memoryMillisecondsWaitNextIncrease, t::setMemoryMillisecondsWaitNextIncrease);
-        applyTo(memoryFillIncrementFraction, t::setMemoryFillIncrementFraction);
-        applyTo(memoryFillTargetFraction, t::setMemoryFillTargetFraction);
-        applyTo(memoryCronExpression, t::setMemoryCronExpression);
-
-        applyTo(cpuActive, t::setCpuActive);
-        applyTo(cpuMillisecondsHoldLoad, t::setCpuMillisecondsHoldLoad);
-        applyTo(cpuLoadTargetFraction, t::setCpuLoadTargetFraction);
-        applyTo(cpuCronExpression, t::setCpuCronExpression);
-
-        applyTo(watchedCustomServices, t::setWatchedCustomServices);
+        try {
+            new ObjectMapper().updateValue(t, this);
+        } catch (JsonMappingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/WatcherPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/WatcherPropertiesUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import java.util.List;
-import java.util.function.Consumer;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -58,22 +59,11 @@ public class WatcherPropertiesUpdate {
     @Nullable
     private List<Class<?>> beanClasses;
 
-    private <T> void applyTo(T value, Consumer<T> setter) {
-        if (value != null) {
-            setter.accept(value);
-        }
-    }
-
     public void applyTo(WatcherProperties t) {
-        applyTo(controller, t::setController);
-        applyTo(restController, t::setRestController);
-        applyTo(service, t::setService);
-        applyTo(repository, t::setRepository);
-        applyTo(component, t::setComponent);
-        applyTo(restTemplate, t::setRestTemplate);
-        applyTo(webClient, t::setWebClient);
-        applyTo(actuatorHealth, t::setActuatorHealth);
-        applyTo(beans, t::setBeans);
-        applyTo(beanClasses, t::setBeanClasses);
+        try {
+            new ObjectMapper().updateValue(t, this);
+        } catch (JsonMappingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdvice.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdvice.java
@@ -56,7 +56,7 @@ public class ChaosMonkeyDefaultAdvice extends AbstractChaosMonkeyAdvice {
 
             MethodSignature signature = (MethodSignature) pjp.getSignature();
 
-            chaosMonkeyRequestScope.callChaosMonkey(target, createSignature(signature));
+            chaosMonkeyRequestScope.callChaosMonkey(target, createSignature(signature), pjp.getTarget(), signature.getMethod());
         }
         return pjp.proceed();
     }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdvice.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyHealthIndicatorAdvice.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyHealthIndicatorAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ public class ChaosMonkeyHealthIndicatorAdvice extends AbstractChaosMonkeyAdvice 
         if (watcherProperties.isActuatorHealth()) {
             MethodSignature signature = (MethodSignature) pjp.getSignature();
             try {
-                this.chaosMonkeyRequestScope.callChaosMonkey(ChaosTarget.ACTUATOR_HEALTH, createSignature(signature), pjp.getTarget(), signature.getMethod());
+                this.chaosMonkeyRequestScope.callChaosMonkey(ChaosTarget.ACTUATOR_HEALTH, createSignature(signature), pjp.getTarget(),
+                        signature.getMethod());
             } catch (final Exception e) {
                 log.error("Exception occurred", e);
                 health = Health.down(e).build();

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyHealthIndicatorAdvice.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyHealthIndicatorAdvice.java
@@ -37,7 +37,7 @@ public class ChaosMonkeyHealthIndicatorAdvice extends AbstractChaosMonkeyAdvice 
         if (watcherProperties.isActuatorHealth()) {
             MethodSignature signature = (MethodSignature) pjp.getSignature();
             try {
-                this.chaosMonkeyRequestScope.callChaosMonkey(ChaosTarget.ACTUATOR_HEALTH, createSignature(signature));
+                this.chaosMonkeyRequestScope.callChaosMonkey(ChaosTarget.ACTUATOR_HEALTH, createSignature(signature), pjp.getTarget(), signature.getMethod());
             } catch (final Exception e) {
                 log.error("Exception occurred", e);
                 health = Health.down(e).build();

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationChaosMonkeyRequestScopeProfileTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/ChaosDemoApplicationChaosMonkeyRequestScopeProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class ChaosDemoApplicationChaosMonkeyRequestScopeProfileTest {
     void setUp() {
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(monkeySettings, Arrays.asList(latencyAssault, exceptionAssault),
                 Collections.emptyList(), metricsMock, new DefaultChaosToggles(),
-                new DefaultChaosToggleNameMapper(monkeySettings.getChaosMonkeyProperties().getTogglePrefix()));
+                new DefaultChaosToggleNameMapper(monkeySettings.getChaosMonkeyProperties().getTogglePrefix()), (t, m) -> false);
     }
 
     @Test

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class ChaosMonkeyRequestScopeTest {
 
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault),
                 Collections.emptyList(), metricEventPublisherMock, new DefaultChaosToggles(),
-                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()));
+                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
     }
 
     @Test
@@ -256,7 +256,7 @@ class ChaosMonkeyRequestScopeTest {
             given(customAssault.isActive()).willReturn(true);
             ChaosMonkeyRequestScope customScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Collections.emptyList(),
                     Collections.singletonList(customAssault), metricEventPublisherMock, new DefaultChaosToggles(),
-                    new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()));
+                    new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
 
             customScope.callChaosMonkey(null, "foo");
             verify(customAssault).attack();
@@ -274,7 +274,7 @@ class ChaosMonkeyRequestScopeTest {
 
         ChaosMonkeyRequestScope customScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Collections.emptyList(),
                 Collections.singletonList(customAssault), metricEventPublisherMock, new DefaultChaosToggles(),
-                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()));
+                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
 
         customScope.callChaosMonkey(null, "foo");
         verify(customAssault, never()).attack();

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/component/ChaosMonkeyRequestScopeTest.java
@@ -70,7 +70,7 @@ class ChaosMonkeyRequestScopeTest {
 
         chaosMonkeyRequestScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Arrays.asList(latencyAssault, exceptionAssault),
                 Collections.emptyList(), metricEventPublisherMock, new DefaultChaosToggles(),
-                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
+                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t, m) -> false);
     }
 
     @Test
@@ -256,7 +256,7 @@ class ChaosMonkeyRequestScopeTest {
             given(customAssault.isActive()).willReturn(true);
             ChaosMonkeyRequestScope customScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Collections.emptyList(),
                     Collections.singletonList(customAssault), metricEventPublisherMock, new DefaultChaosToggles(),
-                    new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
+                    new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t, m) -> false);
 
             customScope.callChaosMonkey(null, "foo");
             verify(customAssault).attack();
@@ -274,7 +274,7 @@ class ChaosMonkeyRequestScopeTest {
 
         ChaosMonkeyRequestScope customScope = new ChaosMonkeyRequestScope(chaosMonkeySettings, Collections.emptyList(),
                 Collections.singletonList(customAssault), metricEventPublisherMock, new DefaultChaosToggles(),
-                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t,m) -> false);
+                new DefaultChaosToggleNameMapper(chaosMonkeyProperties.getTogglePrefix()), (t, m) -> false);
 
         customScope.callChaosMonkey(null, "foo");
         verify(customAssault, never()).attack();

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilterTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilterTest.java
@@ -33,7 +33,6 @@ class RecoverMethodFilterTest {
         }
     }
 
-
     private RecoverMethodFilter recoverMethodFilter;
 
     @BeforeEach

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilterTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/RecoverMethodFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.configuration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.retry.annotation.Recover;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RecoverMethodFilterTest {
+    private static class Pojo {
+        @Recover
+        public Object annotated(final Exception e) {
+            return null;
+        }
+
+        public Object notAnnotated(final Exception e) {
+            return null;
+        }
+    }
+
+
+    private RecoverMethodFilter recoverMethodFilter;
+
+    @BeforeEach
+    void setUp() {
+        recoverMethodFilter = new RecoverMethodFilter();
+    }
+
+    @Test
+    @Recover
+    void filterAnnotated() throws NoSuchMethodException {
+        assertTrue(recoverMethodFilter.filter(new Pojo(), Pojo.class.getDeclaredMethod("annotated", Exception.class)));
+    }
+
+    @Test
+    void filterNotAnnotated() throws NoSuchMethodException {
+        assertFalse(recoverMethodFilter.filter(new Pojo(), Pojo.class.getDeclaredMethod("notAnnotated", Exception.class)));
+    }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyBeanPostProcessorTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyBeanPostProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ public class ChaosMonkeyBeanPostProcessorTest {
     }
 
     private void verifyDependenciesCalledXTimes(int i) {
-        verify(requestScope, times(i)).callChaosMonkey(ChaosTarget.BEAN, simpleName);
+        verify(requestScope, times(i)).callChaosMonkey(eq(ChaosTarget.BEAN), eq(simpleName), any(), any());
         verify(metrics, times(i)).publishMetricEvent(pointcutName, MetricType.BEAN);
         verifyNoMoreInteractions(requestScope, metrics);
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdviceTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyDefaultAdviceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package de.codecentric.spring.boot.chaos.monkey.watcher.advice;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -55,8 +57,8 @@ class ChaosMonkeyDefaultAdviceTest {
 
         proxy.sayHello();
 
-        verify(requestScope, times(1)).callChaosMonkey(ChaosTarget.COMPONENT,
-                "de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello");
+        verify(requestScope, times(1)).callChaosMonkey(eq(ChaosTarget.COMPONENT),
+                eq("de.codecentric.spring.boot.demo.chaos.monkey.component.DemoComponent.sayHello"), any(), any());
         verify(eventPublisher, times(1)).publishMetricEvent("execution.DemoComponent.sayHello", MetricType.COMPONENT);
         verifyNoMoreInteractions(requestScope, eventPublisher);
     }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyPointcutAdvisorIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/ChaosMonkeyPointcutAdvisorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package de.codecentric.spring.boot.chaos.monkey.watcher.advice;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -84,7 +86,7 @@ class ChaosMonkeyPointcutAdvisorIntegrationTest {
     @Test
     public void chaosMonkeyIsCalledWhenComponentIsNotFinal() {
         demoComponent.sayHello();
-        verify(chaosMonkeyRequestScopeMock).callChaosMonkey(ChaosTarget.COMPONENT, demoComponentSimpleName);
+        verify(chaosMonkeyRequestScopeMock).callChaosMonkey(eq(ChaosTarget.COMPONENT), eq(demoComponentSimpleName), any(), any());
         verify(metricsMock).publishMetricEvent(demoComponentPointcutName, MetricType.COMPONENT);
     }
 

--- a/demo-apps/chaos-monkey-demo-app/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app/pom.xml
@@ -54,6 +54,16 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+            <version>6.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/demo-apps/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/retry/RetryComponent.java
+++ b/demo-apps/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/retry/RetryComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.chaos.monkey.chaosdemo;
+package com.example.chaos.monkey.chaosdemo.retry;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
 
-@SpringBootApplication
-@EnableRetry
-public class ChaosDemoApplication {
+@Component
+public class RetryComponent {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ChaosDemoApplication.class, args);
+    @Retryable
+    public String sayHello() {
+        return "Hello from Retryable";
+    }
+
+    @Recover
+    public String recover(Exception e) {
+        return "Hello from Recover: " + e.getMessage();
     }
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/RetryComponentIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/RetryComponentIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,23 @@
  */
 package com.example.chaos.monkey.chaosdemo.controller;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.example.chaos.monkey.chaosdemo.ChaosDemoApplication;
-import com.example.chaos.monkey.chaosdemo.component.HelloComponent;
+import com.example.chaos.monkey.chaosdemo.retry.RetryComponent;
 import de.codecentric.spring.boot.chaos.monkey.configuration.ChaosMonkeyConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-/** @author Benjamin Wilms */
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @SpringBootTest(classes = ChaosDemoApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource("classpath:application-component-test.properties")
-public class HelloComponentIntegrationTest {
+@TestPropertySource("classpath:application-component-retry.properties")
+public class RetryComponentIntegrationTest {
 
     @Autowired
-    private HelloComponent helloComponent;
+    private RetryComponent retryComponent;
 
     @Autowired
     private ChaosMonkeyConfiguration chaosMonkeyConfiguration;
@@ -40,6 +40,6 @@ public class HelloComponentIntegrationTest {
     public void callingPublicMethodOnComponent() {
         assertTrue(chaosMonkeyConfiguration.chaosMonkeySettings().getWatcherProperties().isComponent());
 
-        helloComponent.sayHello();
+        assertEquals("Hello from Recover: Chaos Monkey - RuntimeException", retryComponent.sayHello());
     }
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/RetryEnabledComponentIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/RetryEnabledComponentIntegrationTest.java
@@ -24,12 +24,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = ChaosDemoApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource("classpath:application-component-retry.properties")
-public class RetryComponentIntegrationTest {
+@TestPropertySource(locations = "classpath:application-component-retry.properties", properties = "chaos.monkey.assaults.exceptions-ignored-on-recover=true")
+public class RetryEnabledComponentIntegrationTest {
 
     @Autowired
     private RetryComponent retryComponent;
@@ -41,7 +40,6 @@ public class RetryComponentIntegrationTest {
     public void callingPublicMethodOnComponent() {
         assertTrue(chaosMonkeyConfiguration.chaosMonkeySettings().getWatcherProperties().isComponent());
 
-        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> retryComponent.sayHello());
-        assertEquals("Chaos Monkey - RuntimeException", runtimeException.getMessage());
+        assertEquals("Hello from Recover: Chaos Monkey - RuntimeException", retryComponent.sayHello());
     }
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/resources/application-component-retry.properties
+++ b/demo-apps/chaos-monkey-demo-app/src/test/resources/application-component-retry.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+spring.profiles.active=chaos-monkey
+chaos.monkey.enabled=true
+chaos.monkey.assaults.latencyActive=false
+chaos.monkey.assaults.exceptions-active=true
+chaos.monkey.watcher.component=true
+chaos.monkey.assaults.level=1
+management.endpoint.chaosmonkey.enabled=true
+management.endpoint.chaosmonkeyjmx.enabled=false
+management.endpoints.web.exposure.include=*
+management.server.port=8888


### PR DESCRIPTION

**What**: Recover method should be called in case of service assault.

**Why**: (https://github.com/codecentric/chaos-monkey-spring-boot/issues/395)

**How**: Before an exception is thrown, it is checked whether the method is annotated with `@Recover`. This behavior can be activated via `chaos.monkey.assaults.exceptions-ignored-on-recover`.

**Checklist**: 

- [x] Documentation added
- [x] Changelog updated
- [x] Tests added
- [x] Ready to be merged
