### PR TITLE
use objectmapper in both directions, enhance readability

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricType.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/component/MetricType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,14 +38,13 @@ public enum MetricType {
     private final boolean tagEvent;
 
     MetricType(String metricName, boolean signatureEvent, boolean tagEvent) {
-        this.metricName = metricName;
+        this.metricName = "chaos.monkey." + metricName;
         this.signatureEvent = signatureEvent;
         this.tagEvent = tagEvent;
     }
 
     public String getMetricName() {
-        String metricBaseName = "chaos.monkey.";
-        return metricBaseName + metricName;
+        return metricName;
     }
 
     public boolean isSignatureOnlyEvent() {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,6 @@ public class AssaultProperties {
     }
 
     public AssaultPropertiesUpdate toDto() {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.convertValue(this, AssaultPropertiesUpdate.class);
+        return new ObjectMapper().convertValue(this, AssaultPropertiesUpdate.class);
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyRestTemplateConfiguration.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyRestTemplateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestT
 import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestTemplatePostProcessor;
 import de.codecentric.spring.boot.chaos.monkey.watcher.outgoing.ChaosMonkeyRestTemplateWatcher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/AssaultPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/AssaultPropertiesUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultException;
 import de.codecentric.spring.boot.chaos.monkey.configuration.AssaultProperties;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.validation.AssaultExceptionConstraint;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.validation.AssaultPropertiesUpdateLatencyRangeConstraint;
 import java.util.List;
-import java.util.function.Consumer;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -129,37 +130,11 @@ public class AssaultPropertiesUpdate {
     @Nullable
     private List<String> watchedCustomServices;
 
-    private <T> void applyTo(T value, Consumer<T> setter) {
-        if (value != null) {
-            setter.accept(value);
-        }
-    }
-
     public void applyTo(AssaultProperties t) {
-        applyTo(level, t::setLevel);
-        applyTo(deterministic, t::setDeterministic);
-        applyTo(latencyActive, t::setLatencyActive);
-        applyTo(latencyRangeStart, t::setLatencyRangeStart);
-        applyTo(latencyRangeEnd, t::setLatencyRangeEnd);
-
-        applyTo(exceptionsActive, t::setExceptionsActive);
-        applyTo(exception, t::setException);
-
-        applyTo(killApplicationActive, t::setKillApplicationActive);
-        applyTo(killApplicationCronExpression, t::setKillApplicationCronExpression);
-
-        applyTo(memoryActive, t::setMemoryActive);
-        applyTo(memoryMillisecondsHoldFilledMemory, t::setMemoryMillisecondsHoldFilledMemory);
-        applyTo(memoryMillisecondsWaitNextIncrease, t::setMemoryMillisecondsWaitNextIncrease);
-        applyTo(memoryFillIncrementFraction, t::setMemoryFillIncrementFraction);
-        applyTo(memoryFillTargetFraction, t::setMemoryFillTargetFraction);
-        applyTo(memoryCronExpression, t::setMemoryCronExpression);
-
-        applyTo(cpuActive, t::setCpuActive);
-        applyTo(cpuMillisecondsHoldLoad, t::setCpuMillisecondsHoldLoad);
-        applyTo(cpuLoadTargetFraction, t::setCpuLoadTargetFraction);
-        applyTo(cpuCronExpression, t::setCpuCronExpression);
-
-        applyTo(watchedCustomServices, t::setWatchedCustomServices);
+        try {
+            new ObjectMapper().updateValue(t, this);
+        } catch (JsonMappingException e) {
+            throw new IllegalArgumentException("cannot update values", e);
+        }
     }
 }

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/WatcherPropertiesUpdate.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/endpoints/dto/WatcherPropertiesUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 package de.codecentric.spring.boot.chaos.monkey.endpoints.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import java.util.List;
-import java.util.function.Consumer;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -58,22 +59,11 @@ public class WatcherPropertiesUpdate {
     @Nullable
     private List<Class<?>> beanClasses;
 
-    private <T> void applyTo(T value, Consumer<T> setter) {
-        if (value != null) {
-            setter.accept(value);
-        }
-    }
-
     public void applyTo(WatcherProperties t) {
-        applyTo(controller, t::setController);
-        applyTo(restController, t::setRestController);
-        applyTo(service, t::setService);
-        applyTo(repository, t::setRepository);
-        applyTo(component, t::setComponent);
-        applyTo(restTemplate, t::setRestTemplate);
-        applyTo(webClient, t::setWebClient);
-        applyTo(actuatorHealth, t::setActuatorHealth);
-        applyTo(beans, t::setBeans);
-        applyTo(beanClasses, t::setBeanClasses);
+        try {
+            new ObjectMapper().updateValue(t, this);
+        } catch (JsonMappingException e) {
+            throw new IllegalArgumentException("cannot update values", e);
+        }
     }
 }


### PR DESCRIPTION

**What**: small refactorings in dtos and enum

**Why**: better readability

**How**: small refactorings 

**Checklist**: 
- [ ] Documentation added N/A
 
- [ ] Changelog updated N/A
- [ ] Tests added N/A
     
- [X] Ready to be merged 
