### PR TITLE
Add additional constructor keyword to workaround OWASP HTML sanitization

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -4,6 +4,7 @@
 Built with Spring Boot {spring-boot-version}
 
 === Bug Fixes
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/552[#552] Add alternative constructor keyword to work around HTML sanitization
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
 
 === Improvements
@@ -19,5 +20,8 @@ This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
 - https://github.com/wtfjoke[@WtfJoke]
+- https://github.com/denniseffing[@denniseffing]
+- https://github.com/jens-kaiser[@jens-kaiser]
+- https://github.com/pratik-chauhan[@pratik-chauhan]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,17 +38,24 @@ public class AssaultException {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
-     * special value used to represent constructors. "<init>" was chosen because it
-     * is used as jvm internal name for constructors, which means no method could be
-     * named like this.
+     * special default value used to represent constructors. "<init>" was chosen
+     * because it is used as jvm internal name for constructors, which means no
+     * method could be named like this.
      */
-    private static final String CONSTRUCTOR = "<init>";
+    private static final String DEFAULT_CONSTRUCTOR_KEYWORD = "<init>";
+    /**
+     * special alternative value used to represent constructors. "[init]" was chosen
+     * because it is not affected by request sanitizes (e.g. OWASP HTML sanitizer)
+     * and is not a valid method name.
+     */
+    private static final String ALTERNATIVE_CONSTRUCTOR_KEYWORD = "[init]";
+    private static final List<String> CONSTRUCTOR_KEYWORDS = List.of(DEFAULT_CONSTRUCTOR_KEYWORD, ALTERNATIVE_CONSTRUCTOR_KEYWORD);
 
     @NotNull
     private String type = "java.lang.RuntimeException";
 
     @NotNull
-    private String method = CONSTRUCTOR;
+    private String method = DEFAULT_CONSTRUCTOR_KEYWORD;
 
     @NotNull
     @NestedConfigurationProperty
@@ -78,7 +85,7 @@ public class AssaultException {
     public ThrowableCreator getCreator() throws ReflectiveOperationException {
         Class<?> exceptionClass = getExceptionClass();
         Class<?>[] argumentTypes = getExceptionArgumentTypes().toArray(new Class[0]);
-        if (CONSTRUCTOR.equals(method)) {
+        if (CONSTRUCTOR_KEYWORDS.contains(method)) {
             return new ThrowableConstructor(exceptionClass.asSubclass(Throwable.class).getConstructor(argumentTypes));
         } else {
             return new ThrowableStaticInitializer(exceptionClass.getMethod(method, argumentTypes));

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/configuration/AssaultExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,23 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AssaultExceptionTest {
     @Test
     void testStandardCase() {
         AssaultException assaultException = new AssaultException();
+
+        RuntimeException exception = assertThrows(RuntimeException.class, assaultException::throwExceptionInstance);
+        assertThat(exception.getMessage()).isEqualTo("Chaos Monkey - RuntimeException");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"<init>", "[init]"})
+    void testConstructorKeywords(String keyword) {
+        AssaultException assaultException = new AssaultException();
+        assaultException.setMethod(keyword);
 
         RuntimeException exception = assertThrows(RuntimeException.class, assaultException::throwExceptionInstance);
         assertThat(exception.getMessage()).isEqualTo("Chaos Monkey - RuntimeException");


### PR DESCRIPTION
Closes #545

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: <!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adds an alternative constructor keyword for configuring exception assaults.

**Why**: <!-- Why are these changes necessary? -->
Allows configuring the constructor even when using OWASP HTML sanitization for actuator request payloads.

**How**: <!-- How were these changes implemented? -->
Self explanatory diff.

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
