### PR TITLE
Added Junit test cases to inject fault at JPA repository. (Issue - https://github.com/codecentric/chaos-monkey-spring-boot/issues/554)

### DIFF
--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
@@ -49,7 +49,7 @@ public class ChaosMonkeyBaseClassFilter implements ClassFilter {
     }
 
     private boolean nonFinalOrJdkProxiedClass(Class<?> clazz) {
-        return !Modifier.isFinal(clazz.getModifiers()) || clazz.getName().startsWith("com.sun.proxy.") || clazz.getName().startsWith("jdk.proxy2.");
+        return !Modifier.isFinal(clazz.getModifiers()) || clazz.getName().startsWith("com.sun.proxy.") || clazz.getName().startsWith("jdk.proxy2.") || clazz.getName().contains("jdk.proxy4.");
     }
 
     private boolean hasProblematicFinalMethod(Class<?> clazz) {

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryAnnotatedClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryAnnotatedClassFilter.java
@@ -15,6 +15,8 @@
  */
 package de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.ClassFilter;
 import org.springframework.stereotype.Repository;
 
@@ -22,8 +24,18 @@ import java.lang.reflect.Proxy;
 import java.util.Arrays;
 
 public class RepositoryAnnotatedClassFilter implements ClassFilter {
+    private static final Logger log = LoggerFactory.getLogger(RepositoryAnnotatedClassFilter.class);
+
     @Override
     public boolean matches(Class<?> clazz) {
+        if(clazz.isAnnotationPresent(Repository.class)
+                // if a repository is proxied by spring the annotation can only be found on the
+                // implemented interface
+                || Proxy.isProxyClass(clazz) && Arrays.stream(clazz.getInterfaces()).anyMatch(i -> i.isAnnotationPresent(Repository.class))){
+
+            log.info("Repository class which is matches RepositoryAnnotationFilter condition"+ clazz);
+        }
+
         return clazz.isAnnotationPresent(Repository.class)
                 // if a repository is proxied by spring the annotation can only be found on the
                 // implemented interface

--- a/demo-apps/chaos-monkey-demo-app/src/main/resources/application.properties
+++ b/demo-apps/chaos-monkey-demo-app/src/main/resources/application.properties
@@ -29,5 +29,5 @@ chaos.monkey.assaults.level=1
 management.endpoint.chaosmonkey.enabled=true
 management.endpoint.chaosmonkeyjmx.enabled=false
 management.endpoints.web.exposure.include=*
-management.server.port=8888
+#management.server.port=8888
 

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/HelloControllerIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/controller/HelloControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.example.chaos.monkey.chaosdemo.ChaosDemoApplication;
 import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.AssaultPropertiesUpdate;
+import de.codecentric.spring.boot.chaos.monkey.endpoints.dto.WatcherPropertiesUpdate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalManagementPort;
@@ -74,6 +75,31 @@ public class HelloControllerIntegrationTest {
         assertEquals(HttpStatus.OK, assaultResponse.getStatusCode());
 
         ResponseEntity<String> response = testRestTemplate.getForEntity("/goodbye", String.class);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void whenExceptionAssaultIsActivatedExpectExceptionIsThrownFromRepository() {
+        AssaultPropertiesUpdate assault = new AssaultPropertiesUpdate();
+        assault.setLevel(1);
+        assault.setExceptionsActive(true);
+        assault.setLatencyActive(false);
+
+        ResponseEntity<String> assaultResponse = testRestTemplate
+                .postForEntity("http://localhost:" + managementPort + "/actuator/chaosmonkey/assaults", assault, String.class);
+        assertEquals(HttpStatus.OK, assaultResponse.getStatusCode());
+
+        WatcherPropertiesUpdate watcher = new WatcherPropertiesUpdate();
+        watcher.setRepository(true);
+        watcher.setController(false);
+        watcher.setComponent(false);
+        watcher.setRestController(false);
+        watcher.setService(false);
+        ResponseEntity<String> watcherResponse = testRestTemplate
+                .postForEntity("http://localhost:" + managementPort + "/actuator/chaosmonkey/watchers", watcher, String.class);
+        assertEquals(HttpStatus.OK, watcherResponse.getStatusCode());
+
+        ResponseEntity<String> response = testRestTemplate.getForEntity("/dbgreet", String.class);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: 
**Why**:  
**How**: <!-- How were these changes implemented? -->

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [ ] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added
      <!-- Thank you so much for that! -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Added Junit test cases for Issue- [v 3.2.0] Not Working: Exception Assault using CM4SB (chaos monkey for spring boot) in Spring Data JPA Repository](https://github.com/codecentric/chaos-monkey-spring-boot/issues/554)

Though junit test cases working as expected meaning it is able to inject fault at repository method, but same is not working when applying assault-watcher through REST Endpoint for repository method.

Please refer below recording -
[Recording](https://github.com/user-attachments/assets/bae9fa26-9b67-4db4-b3b5-1ba96e76c748
)
