### PR TITLE
Fix repository watchers not correctly recognizing Spring Data repositories due to issues when matching their proxy package name

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -5,6 +5,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/564[#564] Fixed repository watchers not correctly recognizing Spring Data repositories due to issues when matching their proxy package name.
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -16,5 +17,9 @@ Built with Spring Boot {spring-boot-version}
 This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/octocat[@denniseffing]
+- https://github.com/octocat[@WtfJoke]
+- https://github.com/octocat[@jens-kaiser]
+- https://github.com/octocat[@pratik-chauhan]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/ChaosMonkeyBaseClassFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter;
 
 import de.codecentric.spring.boot.chaos.monkey.configuration.WatcherProperties;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.aop.ClassFilter;
 import org.springframework.web.filter.GenericFilterBean;
@@ -49,7 +51,7 @@ public class ChaosMonkeyBaseClassFilter implements ClassFilter {
     }
 
     private boolean nonFinalOrJdkProxiedClass(Class<?> clazz) {
-        return !Modifier.isFinal(clazz.getModifiers()) || clazz.getName().startsWith("com.sun.proxy.") || clazz.getName().startsWith("jdk.proxy2.");
+        return !Modifier.isFinal(clazz.getModifiers()) || Proxy.isProxyClass(clazz);
     }
 
     private boolean hasProblematicFinalMethod(Class<?> clazz) {


### PR DESCRIPTION
**What**: We now use the `Proxy.isProxyClass` method instead of checking for package name prefixes.

**Why**: This is more reliable due to changing proxy package names.

Apparently, the package name of JDK proxies used by Spring Data repositories evolves over time. Testing with different JDK versions influenced the proxy package used by the repositories. Depending on the used version, we encountered the packages:
  - `com.sun.proxy` (JDK 8)
  - `jdk.proxy2` (JDK 11)
  - `jdk.proxy3` (JDK 16)
  - `jdk.proxy4` (JDK 17)

We therefore assume that the proxy package changes depending on the JDK version used.

HOWEVER: For some reason when executing the integration test `ChaosMonkeyRepositoryWatcherIntegrationTest` we encounter the package `jdk.proxy2` even though the tests were executed with JDK 21. This contradicts our theory that the proxy package changes depending on the JDK version only. We couldn't figure out why, but we didn't care anymore 🙃

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [ ] Tests added N/A (we couldn't figure out how to test this reliably)
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
