### PR TITLE
Fix repositories being attacked multiple times per call

### DIFF
--- a/chaos-monkey-docs/src/main/asciidoc/changes.adoc
+++ b/chaos-monkey-docs/src/main/asciidoc/changes.adoc
@@ -5,6 +5,7 @@ Built with Spring Boot {spring-boot-version}
 
 === Bug Fixes
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
+- https://github.com/codecentric/chaos-monkey-spring-boot/pull/567[#567] Fix deterministic attacks on Spring Data repositories not working correctly
 
 === Improvements
 // - https://github.com/codecentric/chaos-monkey-spring-boot/pull/xxx[#xxx] Added example entry. Please don't remove.
@@ -16,5 +17,9 @@ Built with Spring Boot {spring-boot-version}
 This release was only possible because of these great humans ❤️:
 
 // - https://github.com/octocat[@octocat]
+- https://github.com/octocat[@denniseffing]
+- https://github.com/octocat[@WtfJoke]
+- https://github.com/octocat[@jens-kaiser]
+- https://github.com/octocat[@pratik-chauhan]
 
 Thank you for your support!

--- a/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryClassFilter.java
+++ b/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/watcher/advice/filter/RepositoryClassFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.watcher.advice.filter;
+
+import jakarta.annotation.Nonnull;
+import org.springframework.aop.ClassFilter;
+
+import java.lang.reflect.Proxy;
+
+public class RepositoryClassFilter implements ClassFilter {
+    private static final String SPRING_DATA_REPOSITORY_CLASS_REF = "org.springframework.data.repository.Repository";
+
+    private final Class<?> repositoryClass;
+
+    public RepositoryClassFilter() throws ClassNotFoundException {
+        repositoryClass = Class.forName(SPRING_DATA_REPOSITORY_CLASS_REF);
+    }
+
+    @Override
+    public boolean matches(@Nonnull Class<?> clazz) {
+        return Proxy.isProxyClass(clazz) && repositoryClass.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public String toString() {
+        return "RepositoryClassFilter{repositoryClass=" + SPRING_DATA_REPOSITORY_CLASS_REF + '}';
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        return other instanceof RepositoryClassFilter;
+    }
+
+    @Override
+    public int hashCode() {
+        return SPRING_DATA_REPOSITORY_CLASS_REF.hashCode();
+    }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyDeterministicRepositoryWatcherIntegrationTest.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/chaos/monkey/watcher/ChaosMonkeyDeterministicRepositoryWatcherIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.spring.boot.chaos.monkey.watcher;
+
+import de.codecentric.spring.boot.demo.chaos.monkey.ChaosDemoApplication;
+import de.codecentric.spring.boot.demo.chaos.monkey.repository.DemoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+
+@SpringBootTest(properties = {"chaos.monkey.watcher.repository=true", "chaos.monkey.assaults.exceptions-active=true",
+        "chaos.monkey.assaults.deterministic=true", "chaos.monkey.assaults.level=2",
+        "chaos.monkey.enabled=true"}, classes = {ChaosDemoApplication.class})
+@ActiveProfiles("chaos-monkey")
+public class ChaosMonkeyDeterministicRepositoryWatcherIntegrationTest {
+
+    @Autowired
+    private DemoRepository demoRepository;
+
+    @Test
+    public void shouldThrowExceptionOnEverySecondCall() {
+        assertThatNoException().isThrownBy(() -> demoRepository.count());
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> demoRepository.count());
+        assertThatNoException().isThrownBy(() -> demoRepository.count());
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> demoRepository.count());
+    }
+}

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/CrudDemoRepository.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/CrudDemoRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,5 @@ package de.codecentric.spring.boot.demo.chaos.monkey.repository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CrudDemoRepository extends CrudRepository<Hello, Long> {
 }

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/DemoRepository.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/DemoRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 /** @author Benjamin Wilms */
-@Repository
 public interface DemoRepository extends CrudRepository<Hello, Long> {
 
     void dummyPublicSaveMethod();

--- a/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/DemoRepositoryJDBC.java
+++ b/chaos-monkey-spring-boot/src/test/java/de/codecentric/spring/boot/demo/chaos/monkey/repository/DemoRepositoryJDBC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo-apps/chaos-monkey-demo-app-jdbc/pom.xml
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2018-2025 the original author or authors.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.codecentric</groupId>
+        <artifactId>chaos-monkey-dependencies</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../chaos-monkey-dependencies</relativePath>
+    </parent>
+
+    <artifactId>chaos-monkey-demo-app-jdbc</artifactId>
+    <description>Chaos Monkey for Spring Boot simple demo app with Spring Data JDBC</description>
+    <name>chaos-monkey-demo-app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>chaos-monkey-spring-boot</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <version>${spring-boot.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplication.java
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/ChaosDemoApplication.java
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.chaos.monkey.chaosdemo.repo;
+package com.example.chaos.monkey.chaosdemo;
 
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-/** @author Benjamin Wilms */
-public interface HelloRepo extends CrudRepository<Hello, Long> {
+@SpringBootApplication
+public class ChaosDemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ChaosDemoApplication.class, args);
+    }
 }

--- a/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/Person.java
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/Person.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.chaos.monkey.chaosdemo.repo;
+package com.example.chaos.monkey.chaosdemo;
 
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.annotation.Id;
 
-/** @author Benjamin Wilms */
-public interface HelloRepo extends CrudRepository<Hello, Long> {
+public record Person(@Id Long id, String name) {
 }

--- a/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/PersonRepository.java
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/src/main/java/com/example/chaos/monkey/chaosdemo/PersonRepository.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.chaos.monkey.chaosdemo.repo;
+package com.example.chaos.monkey.chaosdemo;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
-/** @author Benjamin Wilms */
-public interface HelloRepo extends CrudRepository<Hello, Long> {
+public interface PersonRepository extends CrudRepository<Person, Long> {
 }

--- a/demo-apps/chaos-monkey-demo-app-jdbc/src/main/resources/application.properties
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2018-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+spring.profiles.active=chaos-monkey
+chaos.monkey.enabled=true
+chaos.monkey.assaults.level=1

--- a/demo-apps/chaos-monkey-demo-app-jdbc/src/test/java/com/example/chaos/monkey/chaosdemo/RepositoryWatcherIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app-jdbc/src/test/java/com/example/chaos/monkey/chaosdemo/RepositoryWatcherIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.chaos.monkey.chaosdemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@SpringBootTest(properties = {"chaos.monkey.assaults.exceptions-active=true", "chaos.monkey.watcher.repository=true",
+        "chaos.monkey.assaults.level=1",})
+class RepositoryWatcherIntegrationTest {
+
+    @Autowired
+    private PersonRepository crudRepository;
+
+    @Test
+    void shouldAttackDefaultRepository() {
+        System.out.println("RUNNING DEFAULT TEST");
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(crudRepository::count);
+    }
+}

--- a/demo-apps/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/repo/HelloRepoJpa.java
+++ b/demo-apps/chaos-monkey-demo-app/src/main/java/com/example/chaos/monkey/chaosdemo/repo/HelloRepoJpa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 /** @author Benjamin Wilms */
-@Repository
 public interface HelloRepoJpa extends JpaRepository<Hello, Long> {
 }

--- a/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/repo/RepositoryWatcherIntegrationTest.java
+++ b/demo-apps/chaos-monkey-demo-app/src/test/java/com/example/chaos/monkey/chaosdemo/repo/RepositoryWatcherIntegrationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.chaos.monkey.chaosdemo.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@SpringBootTest(properties = {"spring.profiles.active=chaos-monkey", "chaos.monkey.enabled=true", "chaos.monkey.assaults.exceptions-active=true",
+        "chaos.monkey.watcher.repository=true", "chaos.monkey.assaults.level=1", "chaos.monkey.assaults.latency-active=false"})
+class RepositoryWatcherIntegrationTest {
+
+    @Autowired
+    private HelloRepo defaultRepository;
+    @Autowired
+    private HelloRepoJpa jpaRepository;
+    @Autowired
+    private HelloRepoAnnotation repositoryDefinitionRepository;
+
+    @Test
+    void shouldAttackDefaultRepository() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(defaultRepository::count);
+    }
+
+    @Test
+    void shouldAttackJpaRepository() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(jpaRepository::count);
+    }
+
+    @Test
+    void shouldAttackRepositoryDefinitionRepository() {
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> repositoryDefinitionRepository.findById(0L));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <module>chaos-monkey-dependencies</module>
     <module>chaos-monkey-spring-boot</module>
     <module>demo-apps/chaos-monkey-demo-app</module>
+    <module>demo-apps/chaos-monkey-demo-app-jdbc</module>
     <module>demo-apps/chaos-monkey-demo-app-unleash-toggles</module>
     <module>demo-apps/chaos-monkey-web-reactive-app</module>
     <module>demo-apps/chaos-monkey-demo-app-naked</module>


### PR DESCRIPTION
Closes #566

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.adoc file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:  
The [ChaosMonkeyAdvisorConfiguration.java](https://github.com/codecentric/chaos-monkey-spring-boot/blob/dfb8c94782cdd33cbd64d0b89889c5f77c87e2b1/chaos-monkey-spring-boot/src/main/java/de/codecentric/spring/boot/chaos/monkey/configuration/ChaosMonkeyAdvisorConfiguration.java#L95-L95) is changed so that the Chaos Monkey AOP advice is no longer running multiple times per repository.

**Why**:
Multiple pointcuts matched for JPA and JDBC repositories leading to multiple Chaos Monkey executions per call. This broke the deterministic attacks feature.

**How**:
The pointcut advisor beans for JPA and JDBC repositories were merged into a single pointcut advisor bean. This guarantees that the advice is only being run once per repository call.

**Checklist**: <!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes
to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
      <!-- Docs can be found in the folder `chaos-monkey-docs/src/main/asciidoc/` -->
- [x] Changelog updated
      <!-- Changes can be found in the file `chaos-monkey-docs/src/main/asciidoc/changes.adoc` -->
- [x] Tests added
      <!-- Thank you so much for that! -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
